### PR TITLE
Fix syntax notice in m_require_auth

### DIFF
--- a/2.0/m_require_auth.cpp
+++ b/2.0/m_require_auth.cpp
@@ -144,7 +144,7 @@ class CommandGALine: public Command
 		: Command(c, linetype+"LINE", 1, 3)
 	{
 		flags_needed = 'o';
-		this->syntax = "<nick> [<duration> :<reason>]";
+		this->syntax = "[user@host] [<duration> :<reason>]";
 		this->linename = linetype;
 		statschar = stats;
 	}

--- a/2.0/m_require_auth.cpp
+++ b/2.0/m_require_auth.cpp
@@ -144,7 +144,7 @@ class CommandGALine: public Command
 		: Command(c, linetype+"LINE", 1, 3)
 	{
 		flags_needed = 'o';
-		this->syntax = "[user@host] [<duration> :<reason>]";
+		this->syntax = "<ident@host> [<duration> :<reason>]";
 		this->linename = linetype;
 		statschar = stats;
 	}


### PR DESCRIPTION
As with g-line, syntax should be in `[user@host]`, not `<nick>`