### PR TITLE
Port all of my modules to 3.0a1.

### DIFF
--- a/3.0/m_autodrop.cpp
+++ b/3.0/m_autodrop.cpp
@@ -1,0 +1,69 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2014-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModConfig: <autodrop commands="CONNECT DELETE GET HEAD OPTIONS PATCH POST PUT TRACE">
+/// $ModDepends: core 3.0
+/// $ModDesc: Allows clients to be automatically dropped if they execute certain commands before registration.
+
+
+#include "inspircd.h"
+
+class ModuleAutoDrop : public Module
+{
+ private:
+	std::vector<std::string> Commands;
+
+ public:
+	void Prioritize() CXX11_OVERRIDE
+	{
+		ServerInstance->Modules->SetPriority(this, I_OnPreCommand, PRIORITY_FIRST);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		Commands.clear();
+
+		ConfigTag* tag = ServerInstance->Config->ConfValue("autodrop");
+		std::string commandList = tag->getString("commands", "CONNECT DELETE GET HEAD OPTIONS PATCH POST PUT TRACE");
+
+		irc::spacesepstream stream(commandList);
+		std::string token;
+		while (stream.GetToken(token))
+		{
+			Commands.push_back(token);
+		}
+	}
+
+	ModResult OnPreCommand(std::string& command, std::vector<std::string>&, LocalUser* user, bool, const std::string&) CXX11_OVERRIDE
+	{
+		if (user->registered == REG_ALL || std::find(Commands.begin(), Commands.end(), command) == Commands.end())
+			return MOD_RES_PASSTHRU;
+
+		user->eh.SetError("Dropped by " MODNAME);
+		return MOD_RES_DENY;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Allows clients to be automatically dropped if they execute certain commands before registration.");
+	}
+};
+
+MODULE_INIT(ModuleAutoDrop)

--- a/3.0/m_autokick.cpp
+++ b/3.0/m_autokick.cpp
@@ -1,0 +1,77 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2014-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModConfig: <autokick message="Banned">
+/// $ModDepends: core 3.0
+/// $ModDesc: Automatically kicks people who match a banned mask.
+
+
+#include "inspircd.h"
+
+class ModeWatcherBan : public ModeWatcher
+{
+ public:
+	std::string Reason;
+
+	ModeWatcherBan(Module* Creator) : ModeWatcher(Creator, "ban", MODETYPE_CHANNEL) { }
+
+	void AfterMode(User* source, User*, Channel* channel, const std::string& parameter, bool adding) CXX11_OVERRIDE
+	{
+		if (adding)
+		{
+			unsigned int rank = channel->GetPrefixValue(source);
+
+			const Channel::MemberMap& users = channel->GetUsers();
+			Channel::MemberMap::const_iterator iter = users.begin();
+
+			while (iter != users.end())
+			{
+				// KickUser invalidates the iterator so copy and increment it here.
+				Channel::MemberMap::const_iterator it = iter++;
+				if (IS_LOCAL(it->first) && rank > channel->GetPrefixValue(it->first) && channel->CheckBan(it->first, parameter))
+				{
+					channel->KickUser(ServerInstance->FakeClient, it->first, Reason.c_str());
+				}
+			}
+		}
+	}
+};
+
+class ModuleAutoKick : public Module
+{
+ private:
+	ModeWatcherBan mw;
+
+ public:
+	ModuleAutoKick() : mw(this) { }
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("autokick");
+		mw.Reason = tag->getString("message", "Banned");
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Automatically kicks people who match a banned mask.", VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleAutoKick)

--- a/3.0/m_custompenalty.cpp
+++ b/3.0/m_custompenalty.cpp
@@ -1,0 +1,70 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2013-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModConfig: <penalty name="INVITE" value="60">
+/// $ModDepends: core 3.0
+/// $ModDesc: Allows the customisation of penalty levels.
+
+
+#include "inspircd.h"
+
+class ModuleCustomPenalty : public Module
+{
+ private:
+	void SetPenalties()
+	{
+		ConfigTagList tags = ServerInstance->Config->ConfTags("penalty");
+		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		{
+			ConfigTag* tag = i->second;
+
+			std::string name = tag->getString("name");
+			int penalty = (int)tag->getInt("value", 1, 1);
+
+			Command* command = ServerInstance->Parser.GetHandler(name);
+			if (!command)
+			{
+				ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Warning: unable to find command: " + name);
+				continue;
+			}
+
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Setting the penalty for %s to %d", name.c_str(), penalty);
+			command->Penalty = penalty;
+		}
+	}
+
+ public:
+	void init() CXX11_OVERRIDE
+	{
+		SetPenalties();
+	}
+
+	void OnLoadModule(Module*) CXX11_OVERRIDE
+	{
+		SetPenalties();
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Allows the customisation of penalty levels.");
+	}
+};
+
+MODULE_INIT(ModuleCustomPenalty)

--- a/3.0/m_forceident.cpp
+++ b/3.0/m_forceident.cpp
@@ -1,0 +1,50 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2013-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModConfig: <connect forceident="example">
+/// $ModDepends: core 3.0
+/// $ModDesc: Allows forcing idents on users based on their connect class.
+
+
+#include "inspircd.h"
+
+class ModuleForceIdent : public Module
+{
+ public:
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = user->MyClass->config;
+		std::string ident = tag->getString("forceident");
+		if (ServerInstance->IsIdent(ident.c_str()))
+		{
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Setting ident of user '%s' (%s) in class '%s' to '%s'.",
+				user->nick.c_str(), user->uuid.c_str(), user->MyClass->name.c_str(), ident.c_str());
+			user->ident = ident;
+			user->InvalidateCache();
+		}
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Allows forcing idents on users based on their connect class.");
+	}
+};
+
+MODULE_INIT(ModuleForceIdent)

--- a/3.0/m_identmeta.cpp
+++ b/3.0/m_identmeta.cpp
@@ -1,0 +1,52 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2014-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModDepends: core 3.0
+/// $ModDesc: Stores the ident given in USER as metadata.
+
+
+#include "inspircd.h"
+
+class ModuleIdentMeta : public Module
+{
+ private:
+	StringExtItem ext;
+
+ public:
+	ModuleIdentMeta()
+		: ext("user-ident", ExtensionItem::EXT_USER, this) { }
+
+	void OnChangeIdent(User* user, const std::string& ident) CXX11_OVERRIDE
+	{
+		if (IS_LOCAL(user) && ext.get(user) == NULL)
+		{
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Setting ident metadata of %s to %s.",
+				user->nick.c_str(), ident.c_str());
+			ext.set(user, ident);
+		}
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Stores the ident given in USER as metadata.");
+	}
+};
+
+MODULE_INIT(ModuleIdentMeta)

--- a/3.0/m_rotatelog.cpp
+++ b/3.0/m_rotatelog.cpp
@@ -1,0 +1,77 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModConfig: <rotatelog period="3600">
+/// $ModDepends: core 3.0
+/// $ModDesc: Rotates the log files after a defined period.
+
+
+#include "inspircd.h"
+
+class RotateLogTimer : public Timer
+{
+ public:
+	RotateLogTimer() : Timer(3600, true) { }
+
+	bool Tick(time_t) CXX11_OVERRIDE
+	{
+		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Rotating log files ...");
+		ServerInstance->Logs->CloseLogs();
+
+		ServerInstance->Logs->OpenFileLogs();
+		ServerInstance->Logs->Log(MODNAME, LOG_DEFAULT, "Log files have been rotated!");
+		return true;
+	}
+};
+
+class ModuleRotateLog : public Module
+{
+ private:
+	 RotateLogTimer* timer;
+
+ public:
+	ModuleRotateLog()
+	{
+		timer = new RotateLogTimer();
+	}
+
+	~ModuleRotateLog()
+	{
+		ServerInstance->Timers.DelTimer(timer);
+	}
+
+	void init() CXX11_OVERRIDE
+	{
+		ServerInstance->Timers.AddTimer(timer);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("rotatelog");
+		timer->SetInterval(tag->getInt("period", 3600));
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Rotates the log files after a defined period.");
+	}
+};
+
+MODULE_INIT(ModuleRotateLog)

--- a/3.0/m_solvemsg.cpp
+++ b/3.0/m_solvemsg.cpp
@@ -1,0 +1,127 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2015-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModDepends: core 3.0
+/// $ModDesc: Requires users to solve a basic maths problem before messaging others.
+
+
+#include "inspircd.h"
+
+struct Problem
+{
+	int first;
+	int second;
+	bool warned;
+};
+
+class CommandSolve : public SplitCommand
+{
+ private:
+	SimpleExtItem<Problem>& ext;
+
+ public:
+	CommandSolve(Module* Creator, SimpleExtItem<Problem>& Ext)
+		: SplitCommand(Creator, "SOLVE", 1, 1)
+		, ext(Ext)
+	{
+	}
+
+	CmdResult HandleLocal(const std::vector<std::string>& parameters, LocalUser* user) CXX11_OVERRIDE
+	{
+		if (user->exempt)
+		{
+			user->WriteNotice("*** You do not need to solve a problem!");
+			return CMD_FAILURE;
+		}
+
+		Problem* problem = ext.get(user);
+		if (!problem)
+		{
+			user->WriteNotice("** You have already solved your problem!");
+			return CMD_FAILURE;
+		}
+
+		int result = ConvToInt(parameters[0]);
+		if (result != (problem->first + problem->second))
+		{
+			user->WriteNotice(InspIRCd::Format("*** %s is not the correct answer.", parameters[0].c_str()));
+			user->CommandFloodPenalty += 10000;
+			return CMD_FAILURE;
+		}
+
+		ext.unset(user);
+		user->WriteNotice(InspIRCd::Format("*** %s is the correct answer!", parameters[0].c_str()));
+		return CMD_SUCCESS;
+	}
+};
+
+class ModuleSolveMessage : public Module
+{
+ private:
+	SimpleExtItem<Problem> ext;
+	CommandSolve cmd;
+
+ public:
+	ModuleSolveMessage()
+		: ext("solve-message", ExtensionItem::EXT_USER, this)
+		, cmd(this, ext)
+	{
+	}
+
+	void OnUserInit(LocalUser* user) CXX11_OVERRIDE
+	{
+		Problem problem;
+		problem.first = ServerInstance->GenRandomInt(9);
+		problem.second = ServerInstance->GenRandomInt(9);
+		problem.warned = false;
+		ext.set(user, problem);
+	}
+
+	ModResult OnUserPreMessage(User* user, void* dest, int target_type, std::string&, char, CUList&, MessageType) CXX11_OVERRIDE
+	{
+		LocalUser* source = IS_LOCAL(user);
+		if (!source || source->exempt || target_type != TYPE_USER)
+			return MOD_RES_PASSTHRU;
+
+		User* target = static_cast<User*>(dest);
+		if (target->server->IsULine())
+			return MOD_RES_PASSTHRU;
+
+		Problem* problem = ext.get(user);
+		if (!problem)
+			return MOD_RES_PASSTHRU;
+
+		if (problem->warned)
+			return MOD_RES_DENY;
+
+		user->WriteNotice("*** Before you can send messages you must solve the following problem:");
+		user->WriteNotice(InspIRCd::Format("*** What is %d + %d?", problem->first, problem->second));
+		user->WriteNotice("*** You can enter your answer using /QUOTE SOLVE <answer>");
+		problem->warned = true;
+		return MOD_RES_DENY;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Requires users to solve a basic maths problem before messaging others.");
+	}
+};
+
+MODULE_INIT(ModuleSolveMessage)

--- a/3.0/m_stats_unlinked.cpp
+++ b/3.0/m_stats_unlinked.cpp
@@ -1,0 +1,87 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2014-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModDepends: core 3.0
+/// $ModDesc: Adds stats character 'X' which shows unlinked servers.
+
+
+#include "inspircd.h"
+
+class ModuleStatsUnlinked : public Module
+{
+ private:
+	std::map<std::string, int> LinkableServers;
+
+	static bool IsServerLinked(const ProtocolInterface::ServerList& linkedServers, const std::string& serverName)
+	{
+		for (ProtocolInterface::ServerList::const_iterator it = linkedServers.begin(); it != linkedServers.end(); ++it)
+		{
+			if (it->servername == serverName)
+				return true;
+		}
+		return false;
+	}
+
+ public:
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		LinkableServers.clear();
+
+		ConfigTagList tags = ServerInstance->Config->ConfTags("link");
+		for (ConfigIter it = tags.first; it != tags.second; ++it)
+		{
+			std::string serverName = it->second->getString("name");
+			int serverPort = it->second->getInt("port");
+			if (!serverName.empty() && serverName.size() <= 64 && serverName.find('.') != std::string::npos && serverPort)
+			{
+				// There is currently no way to prioritize the init() function so we
+				// reimplement the checks from m_spanningtree here.
+				LinkableServers[serverName] = serverPort;
+			}
+		}
+	}
+
+	ModResult OnStats(Stats::Context& stats) CXX11_OVERRIDE
+	{
+		if (stats.GetSymbol() != 'X')
+			return MOD_RES_PASSTHRU;
+
+		ProtocolInterface::ServerList linkedServers;
+		ServerInstance->PI->GetServerList(linkedServers);
+
+		for (std::map<std::string, int>::iterator it = LinkableServers.begin(); it != LinkableServers.end(); ++it)
+		{
+			if (!IsServerLinked(linkedServers, it->first))
+			{
+				// ProtoServer does not have a port so we use the port from the config here.
+				stats.AddRow(247, " X " + it->first + " " + ConvToStr(it->second));
+			}
+		}
+		return MOD_RES_DENY;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Adds stats character 'X' which shows unlinked servers.");
+	}
+};
+
+MODULE_INIT(ModuleStatsUnlinked)
+

--- a/3.0/m_svsoper.cpp
+++ b/3.0/m_svsoper.cpp
@@ -1,0 +1,82 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2013-2016 Peter Powell <petpow@saberuk.com>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: Peter "SaberUK" Powell
+/// $ModAuthorMail: petpow@saberuk.com
+/// $ModDepends: core 3.0
+/// $ModDesc: Allows services to forcibly oper a user.
+
+
+#include "inspircd.h"
+
+class CommandSVSOper : public Command
+{
+ public:
+	CommandSVSOper(Module* Creator)
+		: Command(Creator, "SVSOPER", 2, 2)
+	{
+		flags_needed = FLAG_SERVERONLY;
+	}
+
+	CmdResult Handle(const std::vector<std::string>& parameters, User* user) CXX11_OVERRIDE
+	{
+		if (!user->server->IsULine())
+			return CMD_FAILURE;
+
+		User* target = ServerInstance->FindUUID(parameters[0]);
+		if (!target)
+			return CMD_FAILURE;
+
+		if (IS_LOCAL(target))
+		{
+			ServerConfig::OperIndex::iterator iter = ServerInstance->Config->OperTypes.find(parameters[1]);
+			if (iter == ServerInstance->Config->OperTypes.end())
+				return CMD_FAILURE;
+
+			target->Oper(iter->second);
+		}
+		return CMD_SUCCESS;
+	}
+
+	RouteDescriptor GetRouting(User* user, const std::vector<std::string>& parameters) CXX11_OVERRIDE
+	{
+		User* target = ServerInstance->FindUUID(parameters[0]);
+		if (!target)
+			return ROUTE_LOCALONLY;
+		return ROUTE_OPT_UCAST(target->server);
+	}
+};
+
+class ModuleSVSOper : public Module
+{
+ private:
+	CommandSVSOper command;
+
+ public:
+	ModuleSVSOper()
+		: command(this)
+	{
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Allows services to forcibly oper a user.", VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleSVSOper)

--- a/regen-modules
+++ b/regen-modules
@@ -47,7 +47,7 @@ for my $file (<*/m_*.cpp>) {
 	say LIST "module $name $branch.$version https://raw.github.com/inspircd/inspircd-extras/$revision/$file";
 	open(MODULE, $file);
 	while (<MODULE>) {
-		if ($_ =~ /^\/\* \$(\S+): (.+) \*\/$/) {
+		if ($_ =~ /^\/\* \$(\S+): (.+) \*\/$/ || $_ =~ /^\/\/\/ \$(\S+): (.+)/) {
 			if ($1 eq 'ModDepends') {
 				say LIST " depends $2";
 			} elsif ($1 eq 'ModConflicts') {


### PR DESCRIPTION
All of my 2.0 extras modules are present here apart from m_regex_re2 (which was a backport) and m_replaymsg (which is obsoleted by m_ircv3_echomessage in 3.0).

To my knowledge all of these should work fine on 3.0a1 but I would appreciate more eyeballs looking at it if people are interested.