### PR TITLE
m_flashpolicyd: Only destroy the socket if it is over the timeout, no…

### DIFF
--- a/2.0/m_flashpolicyd.cpp
+++ b/2.0/m_flashpolicyd.cpp
@@ -97,7 +97,7 @@ class ModuleFlashPD : public Module
 		for (std::set<FlashPDSocket*>::const_iterator i = sockets.begin(); i != sockets.end(); ++i)
 		{
 			FlashPDSocket* sock = *i;
-			if ((sock->created + timeout > curtime) && (sock->created != 0))
+			if ((sock->created + timeout < curtime) && (sock->created != 0))
 				sock->AddToCull();
 		}
 	}


### PR DESCRIPTION
…t under.

Fixes #96 