### PR TITLE
Fix modules that don't specify a core version constraint.

### DIFF
--- a/2.0/m_dccblock.cpp
+++ b/2.0/m_dccblock.cpp
@@ -23,6 +23,7 @@
 /* $ModAuthor: Jansteen */
 /* $ModAuthorMail: pliantcom@yandex.com */
 /* $ModConfig: <dccblock users="true" channels="false"> */
+/* $ModDepends: core 2.0 */
 
 /* Documentation
    This module is used to completely block DCC from being used on your

--- a/2.0/m_geoipban.cpp
+++ b/2.0/m_geoipban.cpp
@@ -27,6 +27,7 @@
 /* $ModAuthor: Filippo Cortigiani */
 /* $ModAuthorMail: simos@simosnap.org */
 /* $ModDesc: Implements extban +b G: - GeoIP Country Code bans and add county name and country code in whois */
+/* $ModDepends: core 2.0 */
 /* $LinkerFlags: -lGeoIP */
 
 class ModuleGeoIPBan : public Module

--- a/2.0/m_opmoderated.cpp
+++ b/2.0/m_opmoderated.cpp
@@ -20,6 +20,7 @@
 #include "inspircd.h"
 
 /* $ModDesc: Implements channel mode +U and extban 'U' - moderator mute */
+/* $ModDepends: core 2.0 */
 
 class OpModeratedMode : public SimpleChannelModeHandler
 {

--- a/2.0/m_regex_re2.cpp
+++ b/2.0/m_regex_re2.cpp
@@ -32,6 +32,9 @@
 
 #include <re2/re2.h>
 
+/* $ModAuthor: Peter "SaberUK" Powell */
+/* $ModDesc: Regex Provider Module for RE2. */
+/* $ModDepends: core 2.0 */
 /* $LinkerFlags: -lre2 */
 
 class RE2Exception : public ModuleException


### PR DESCRIPTION
This prevents them from appearing on 3.0's module list.

Also, fix m_regex_re2's lack of any kind of module config.