### PR TITLE
Modify m_findxline.cpp to add Xline removal ability, reason matching, and helpop config

### DIFF
--- a/2.0/m_findxline.cpp
+++ b/2.0/m_findxline.cpp
@@ -1,6 +1,7 @@
 /*
  * InspIRCd -- Internet Relay Chat Daemon
  *
+ *   Copyright (C) 2017 genius3000 <genius3000@g3k.solutions>
  *   Copyright (C) 2013 Attila Molnar <attilamolnar@hush.com>
  *
  * This file is part of InspIRCd.  InspIRCd is free software: you can
@@ -18,20 +19,39 @@
 
 /* $ModAuthor: Attila Molnar */
 /* $ModAuthorMail: attilamolnar@hush.com */
-/* $ModDesc: Provides the FINDXLINE command which lets opers search XLines */
+/* $ModDesc: Provides the FINDXLINE and RMXLINE commands which lets opers search and remove XLines */
 /* $ModDepends: core 2.0 */
+
+/* Helpop Lines for the COPER section
+ * Find: '<helpop key="coper" value="Oper Commands
+ * Place 'FINDXLINE RMXLINE   ' before 'FILTER OJOIN'
+ * Re-space 'FILTER OJOIN' to match the current columns
+ * Find: '<helpop key="filter" ...'
+ * Place just above that line:
+<helpop key="findxline" value="/FINDXLINE {<xline type>|*} <ban mask> [<reason>]
+
+This command will list any XLines of the specified type or all (*)
+that match the given ban mask and reason, if specified.">
+
+<helpop key="rmxline" value="/RMXLINE {<xline type>|*} <ban mask> [<reason>]
+
+This command will remove any XLines of the specified type or all (*)
+that match the given ban mask and reason, if specified.">
+
+ */
+
 
 #include "inspircd.h"
 #include "xline.h"
 
 class CommandFindXLine : public Command
 {
-	void List(User* user, const std::string& wildcardstr, const std::string& linetype, XLineLookup* xlines, unsigned int& matched, unsigned int& total)
+	void List(User* user, const std::string& banmask, const std::string& reason, const std::string& linetype, XLineLookup* xlines, unsigned int& matched, unsigned int& total)
 	{
 		for (LookupIter i = xlines->begin(); i != xlines->end(); ++i)
 		{
 			XLine* xline = i->second;
-			if (InspIRCd::Match(xline->Displayable(), wildcardstr))
+			if (InspIRCd::Match(xline->Displayable(), banmask) && InspIRCd::Match(xline->reason, reason))
 			{
 				std::string settime = ServerInstance->TimeString(xline->set_time);
 				std::string expires;
@@ -50,9 +70,9 @@ class CommandFindXLine : public Command
 
  public:
 	CommandFindXLine(Module* mod)
-		: Command(mod, "FINDXLINE", 2)
+		: Command(mod, "FINDXLINE", 2, 3)
 	{
-		syntax = "{<xline type>|*} <wildcard string>";
+		syntax = "{<xline type>|*} <ban mask> [<reason>]";
 		flags_needed = 'o';
 	}
 
@@ -60,16 +80,21 @@ class CommandFindXLine : public Command
 	{
 		unsigned int matched = 0;
 		unsigned int total = 0;
+		std::string reason = "*";
+
+		if (parameters.size() > 2)
+			reason = parameters[2];
+
 		if (parameters[0] == "*")
 		{
-			user->WriteServ("NOTICE %s :Listing all XLines with a match string that matches the wildcard string \"%s\"", user->nick.c_str(), parameters[1].c_str());
+			user->WriteServ("NOTICE %s :Listing all XLines with a ban mask that matches \"%s\" and a reason that matches \"%s\"", user->nick.c_str(), parameters[1].c_str(), reason.c_str());
 
 			std::vector<std::string> xlinetypes = ServerInstance->XLines->GetAllTypes();
 			for (std::vector<std::string>::iterator i = xlinetypes.begin(); i != xlinetypes.end(); ++i)
 			{
 				XLineLookup* xlines = ServerInstance->XLines->GetAll(*i);
 				if (xlines)
-					List(user, parameters[1], *i, xlines, matched, total);
+					List(user, parameters[1], reason, *i, xlines, matched, total);
 			}
 		}
 		else
@@ -84,32 +109,122 @@ class CommandFindXLine : public Command
 				return CMD_FAILURE;
 			}
 
-			user->WriteServ("NOTICE %s :Listing all XLines of type %s with a match string that matches the wildcard string \"%s\"", user->nick.c_str(), parameters[0].c_str(), parameters[1].c_str());
-			List(user, parameters[1], linetype, xlines, matched, total);
+			user->WriteServ("NOTICE %s :Listing all XLines of type %s with a ban mask that matches \"%s\" and a reason that matches \"%s\"", user->nick.c_str(), parameters[0].c_str(), parameters[1].c_str(), reason.c_str());
+			List(user, parameters[1], reason, linetype, xlines, matched, total);
 		}
 
-		user->WriteServ("NOTICE %s :End of list, %u/%u matches", user->nick.c_str(), matched, total);
+		user->WriteServ("NOTICE %s :End of list, %u/%u XLines matched", user->nick.c_str(), matched, total);
+		return CMD_SUCCESS;
+	}
+};
+
+class CommandRmXLine : public Command
+{
+	void Remove(User* user, const std::string& banmask, const std::string& reason, const std::string& linetype, XLineLookup* xlines, unsigned int& matched, unsigned int& total)
+	{
+		/* Add to total first and use safe iteration as lines are removed here */
+		total += xlines->size();
+		LookupIter safei;
+
+		for (LookupIter i = xlines->begin(); i != xlines->end(); )
+		{
+			safei = i;
+			safei++;
+
+			XLine* xline = i->second;
+			if (InspIRCd::Match(xline->Displayable(), banmask) && InspIRCd::Match(xline->reason, reason))
+			{
+				std::string settime = ServerInstance->TimeString(xline->set_time);
+				std::string expires;
+				if (xline->duration == 0)
+					expires = "doesn't expire";
+				else
+					expires = "duration " + ConvToStr(xline->duration) + 's';
+
+				matched++;
+
+				std::string displayable = xline->Displayable();
+				std::string xlineReason = xline->reason;
+				if (ServerInstance->XLines->DelLine(xline->Displayable(), linetype, user))
+				{
+					ServerInstance->SNO->WriteToSnoMask('x', "%s removed XLine of type %s for %s :%s",
+						user->nick.c_str(), linetype.c_str(), displayable.c_str(), xlineReason.c_str());
+				}
+			}
+
+			i = safei;
+		}
+	}
+
+ public:
+	CommandRmXLine(Module* mod)
+		: Command(mod, "RMXLINE", 2, 3)
+	{
+		syntax = "{<xline type>|*} <ban mask> [<reason>]";
+		flags_needed = 'o';
+	}
+
+	CmdResult Handle(const std::vector<std::string>& parameters, User* user)
+	{
+		unsigned int matched = 0;
+		unsigned int total = 0;
+		std::string reason = "*";
+
+		if (parameters.size() > 2)
+			reason = parameters[2];
+
+		if (parameters[0] == "*")
+		{
+			user->WriteServ("NOTICE %s :Removing all XLines with a ban mask that matches \"%s\" and a reason that matches \"%s\"", user->nick.c_str(), parameters[1].c_str(), reason.c_str());
+
+			std::vector<std::string> xlinetypes = ServerInstance->XLines->GetAllTypes();
+			for (std::vector<std::string>::iterator i = xlinetypes.begin(); i != xlinetypes.end(); ++i)
+			{
+				XLineLookup* xlines = ServerInstance->XLines->GetAll(*i);
+				if (xlines)
+					Remove(user, parameters[1], reason, *i, xlines, matched, total);
+			}
+		}
+		else
+		{
+			std::string linetype = parameters[0];
+			std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
+
+			XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
+			if (!xlines)
+			{
+				user->WriteServ("NOTICE %s :Invalid XLine type: %s", user->nick.c_str(), linetype.c_str());
+				return CMD_FAILURE;
+			}
+
+			user->WriteServ("NOTICE %s :Removing all XLines of type %s with a ban mask that matches \"%s\" and a reason that matches \"%s\"", user->nick.c_str(), parameters[0].c_str(), parameters[1].c_str(), reason.c_str());
+			Remove(user, parameters[1], reason, linetype, xlines, matched, total);
+		}
+
+		user->WriteServ("NOTICE %s :End of list, %u/%u XLines removed", user->nick.c_str(), matched, total);
 		return CMD_SUCCESS;
 	}
 };
 
 class ModuleFindXLine : public Module
 {
-	CommandFindXLine cmd;
+	CommandFindXLine findxline;
+	CommandRmXLine rmxline;
  public:
 	ModuleFindXLine()
-		: cmd(this)
+		: findxline(this), rmxline(this)
 	{
 	}
 
 	void init()
 	{
-		ServerInstance->Modules->AddService(cmd);
+		ServerInstance->Modules->AddService(findxline);
+		ServerInstance->Modules->AddService(rmxline);
 	}
 
 	Version GetVersion()
 	{
-		return Version("Provides the FINDXLINE command which lets opers search XLines");
+		return Version("Provides the FINDXLINE and RMXLINE commands which lets opers search and remove XLines");
 	}
 };
 


### PR DESCRIPTION
This PR adds Xline removal ~~ability~~ command and reason matching to m_findxline.cpp as well as helpop config.
~~The command now takes a '-' parameter before the Xline type (or *), which will remove all matching Xlines. The command also accepts an optional 'reason' string, '*' is used if not specified.~~
There is now a second command, '/RMXLINE' which will remove matching Xlines, same syntax as '/FINDXLINE'
Both commands do ban mask and reason matching (reason is optional and will be '*' if not specified).

Testing has been performed on a two server + services test network with removal of all Xlines of a certain type, matching Xlines of a certain type, and matching Xlines of all types (both find and rm).

This PR technically brings the removal functionality of m_rmtkl.cpp (from 1.2/) into m_findxline.cpp (Issue #20)