### PR TITLE
Add feedback message when reloading SSL certificates

### DIFF
--- a/2.0/m_rehashsslsignal.cpp
+++ b/2.0/m_rehashsslsignal.cpp
@@ -50,7 +50,9 @@ class ModuleRehashSSLSignal : public Module
 		if (!signaled)
 			return;
 
-		ServerInstance->Logs->Log("m_rehashsslsignal", DEFAULT, "Got SIGUSR1, reloading SSL credentials");
+		const std::string feedbackmsg = "Got SIGUSR1, reloading SSL credentials";
+		ServerInstance->SNO->WriteGlobalSno('a', feedbackmsg);
+		ServerInstance->Logs->Log("m_rehashsslsignal", DEFAULT, feedbackmsg);
 		const std::string str = "ssl";
 		FOREACH_MOD(I_OnModuleRehash, OnModuleRehash(NULL, str));
 		signaled = 0;


### PR DESCRIPTION
Currently you do not get any feedback message on the IRC server itself
when using kill -SIGUSR1 <PID> when reloading the SSL certificates. This
patch adds the feedbackmessage so you will see this message if you have
snomasks enabled, or you have a channel which logs snomask messages.