### PR TITLE
2.0/m_override_umode: Fix typo in for loop

### DIFF
--- a/2.0/m_override_umode.cpp
+++ b/2.0/m_override_umode.cpp
@@ -109,7 +109,7 @@ class OverrideMode : public ModeHandler
 			else
 			{
 				// Remove this oper from the list
-				for (ActiveOperList::iterator i = activeopers.end(); i != activeopers.end(); ++i)
+				for (ActiveOperList::iterator i = activeopers.begin(); i != activeopers.end(); ++i)
 				{
 					ActiveOper& item = *i;
 					if (item.uuid == dest->uuid)


### PR DESCRIPTION
As found in #125, unsetting the mode was not destroying the ActiveOper object and an "old" version of it would expire even if the mode had been set again.
Easy fix, just a typo in the for loop within mode removal causing the loop to never actually do anything. This has been tested to work correctly.