### PR TITLE
Rewrite m_joinpartspam; improve method and flexibility

### DIFF
--- a/2.0/m_joinpartspam.cpp
+++ b/2.0/m_joinpartspam.cpp
@@ -1,7 +1,7 @@
 /*
  * InspIRCd -- Internet Relay Chat Daemon
  *
- *   Copyright (C) 2016 genius3000 <genius3000@g3k.solutions>
+ *   Copyright (C) 2016-2018 Matt Schatz <genius3000@g3k.solutions>
  *
  * This file is a module for InspIRCd.  InspIRCd is free software: you can
  * redistribute it and/or modify it under the terms of the GNU General Public
@@ -16,36 +16,67 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "inspircd.h"
-
-/* $ModDesc: Adds channel mode +V to ban a user after x per y joins and parts/quits (join/part spam) */
 /* $ModAuthor: genius3000 */
 /* $ModAuthorMail: genius3000@g3k.solutions */
+/* $ModDesc: Adds channel mode +x to block a user after x per y joins and parts/quits (join/part spam) */
 /* $ModDepends: core 2.0 */
+/* $ModConfig: <joinpartspam allowredirect="yes" freeredirect="yes"> */
+
+/* Set 'allowredirect' to "yes" to allow channel redirection. Defaults to no.
+ * Set 'freeredirect' to "yes" to skip the channel operator check. Defaults to no.
+ */
+
+/* Helpop Lines for the CHMODES section
+ * Find: '<helpop key="chmodes" value="Channel Modes'
+ * Place just above the 'z     Blocks non-SSL...' line:
+ x <cycles>:<sec>:<block>[:#channel] Blocks a user after the set
+                    number of Join and Part/Quit cycles in the set
+                    seconds for the given block duration (seconds).
+                    An optional redirect channel can be set.
+ */
 
 /* Special thanks to Attila for the patience and guidance in
  * fixing up some of my initial, poor methods.
  */
 
+#include "inspircd.h"
+
+
+enum
+{
+	RPL_CHANBLOCKED = 545,
+	ERR_INVALIDMODEPARAM = 696
+};
+
 class joinpartspamsettings
 {
- public:
-	unsigned int cycles;
-	unsigned int secs;
-	time_t lastcleanup;
-
 	struct Tracking
 	{
 		time_t reset;
 		unsigned int counter;
 		Tracking() : reset(0), counter(0) { }
 	};
+
 	std::map<std::string, Tracking> cycler;
+	std::map<std::string, time_t> blocked;
+	time_t lastcleanup;
 
-	joinpartspamsettings(unsigned int c, unsigned int s)
-		: cycles(c), secs(s), lastcleanup(ServerInstance->Time()) { }
+ public:
+	unsigned int cycles;
+	unsigned int secs;
+	unsigned int block;
+	std::string redirect;
 
-	/* Called by PostJoin to possibly reset a cycler's Tracking and increment the counter */
+	joinpartspamsettings(unsigned int c, unsigned int s, unsigned int b, std::string& r)
+		: lastcleanup(ServerInstance->Time())
+		, cycles(c)
+		, secs(s)
+		, block(b)
+		, redirect(r)
+	{
+	}
+
+	// Called by PostJoin to possibly reset a cycler's Tracking and increment the counter
 	void addcycle(const std::string& mask)
 	{
 		/* If mask isn't already tracked, set reset time
@@ -69,11 +100,12 @@ class joinpartspamsettings
 	}
 
 	/* Called by PreJoin to check if a cycler's counter exceeds the set cycles,
-	 * Will first clear a cycler if their reset time is up
+	 * adds them to the blocked list if so.
+	 * Will first clear a cycler if their reset time is up.
 	 */
 	bool zapme(const std::string& mask)
 	{
-		/* Only check reset time and counter if they are already tracked as a cycler */
+		// Only check reset time and counter if they are already tracked as a cycler
 		std::map<std::string, Tracking>::iterator it = cycler.find(mask);
 		if (it == cycler.end())
 			return false;
@@ -84,6 +116,7 @@ class joinpartspamsettings
 			cycler.erase(it);
 		else if (tracking.counter >= cycles)
 		{
+			blocked[mask] = ServerInstance->Time() + block;
 			cycler.erase(it);
 			return true;
 		}
@@ -91,10 +124,25 @@ class joinpartspamsettings
 		return false;
 	}
 
-	/* Clear expired entries of non cyclers */
+	// Check if a joining user is blocked, clear them if blocktime is up
+	bool isblocked(const std::string& mask)
+	{
+		std::map<std::string, time_t>::iterator it = blocked.find(mask);
+		if (it == blocked.end())
+			return false;
+
+		if (ServerInstance->Time() > it->second)
+			blocked.erase(it);
+		else
+			return true;
+
+		return false;
+	}
+
+	// Clear expired entries of non cyclers and blocked cyclers
 	void cleanup()
 	{
-		/* 10 minutes should be a reasonable wait time */
+		// 10 minutes should be a reasonable wait time
 		if (ServerInstance->Time() - lastcleanup < 600)
 			return;
 
@@ -109,86 +157,189 @@ class joinpartspamsettings
 			else
 				++it;
 		}
+
+		for (std::map<std::string, time_t>::iterator i = blocked.begin(); i != blocked.end(); )
+		{
+			if (ServerInstance->Time() > i->second)
+				blocked.erase(i++);
+			else
+				++i;
+		}
 	}
 };
 
-/* Handles channel mode +V */
 class JoinPartSpam : public ModeHandler
 {
+	SimpleExtItem<joinpartspamsettings>& ext;
+	bool& allowredirect;
+	bool& freeredirect;
+
+	bool ParseCycles(irc::sepstream& stream, unsigned int& cycles)
+	{
+		std::string strcycles;
+		if (!stream.GetToken(strcycles))
+			return false;
+
+		unsigned int result = ConvToInt(strcycles);
+		if (result < 2 || result > 20)
+			return false;
+
+		cycles = result;
+		return true;
+	}
+
+	bool ParseSeconds(irc::sepstream& stream, unsigned int& seconds)
+	{
+		std::string strseconds;
+		if (!stream.GetToken(strseconds))
+			return false;
+
+		unsigned int result = ConvToInt(strseconds);
+		if (result < 1 || result > 43200)
+			return false;
+
+		seconds = result;
+		return true;
+	}
+
+	bool ParseRedirect(irc::sepstream& stream, std::string& redirect, User* source, Channel* chan)
+	{
+		std::string strredirect;
+		// This parameter is optional
+		if (!stream.GetToken(strredirect))
+			return true;
+
+		if (!allowredirect)
+		{
+			source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, the server admin has disabled channel redirection.",
+				source->nick.c_str(), chan->name.c_str(), GetModeChar(), strredirect.c_str());
+			return false;
+		}
+
+		if (!ServerInstance->IsChannel(strredirect.c_str(), ServerInstance->Config->Limits.ChanMax))
+		{
+			source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, redirect channel needs to be a valid channel name.",
+				source->nick.c_str(), chan->name.c_str(), GetModeChar(), strredirect.c_str());
+			return false;
+		}
+
+		if (chan->name == strredirect)
+		{
+			source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, cannot redirect to myself.",
+				source->nick.c_str(), chan->name.c_str(), GetModeChar(), strredirect.c_str());
+			return false;
+		}
+
+		Channel* c = ServerInstance->FindChan(strredirect);
+		if (!c)
+		{
+			source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, redirect channel must exist.",
+				source->nick.c_str(), chan->name.c_str(), GetModeChar(), strredirect.c_str());
+			return false;
+		}
+
+		if (!freeredirect && c->GetPrefixValue(source) < HALFOP_VALUE)
+		{
+			source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, you need at least halfop in the redirect channel.",
+				source->nick.c_str(), chan->name.c_str(), GetModeChar(), strredirect.c_str());
+			return false;
+		}
+
+		redirect = strredirect;
+		return true;
+	}
+
  public:
-	SimpleExtItem<joinpartspamsettings> ext;
-	JoinPartSpam(Module* Creator) : ModeHandler(Creator, "joinpartspam", 'V', PARAM_SETONLY, MODETYPE_CHANNEL)
-		, ext("joinpartspam", Creator)
+	JoinPartSpam(Module* Creator, SimpleExtItem<joinpartspamsettings>& e, bool& allow, bool& free)
+		: ModeHandler(Creator, "joinpartspam", 'x', PARAM_SETONLY, MODETYPE_CHANNEL)
+		, ext(e)
+		, allowredirect(allow)
+		, freeredirect(free)
 	{
 	}
 
-	ModeAction OnModeChange(User* source, User* dest, Channel* chan, std::string& parameter, bool adding)
+	ModeAction OnModeChange(User* source, User*, Channel* chan, std::string& parameter, bool adding)
 	{
 		if (adding)
 		{
-			std::string::size_type colon = parameter.find(':');
-			if (colon == std::string::npos || parameter.find('-') != std::string::npos)
+			irc::sepstream stream(parameter, ':');
+			unsigned int ncycles, nsecs, nblock;
+			ncycles = nsecs = nblock = 0;
+			std::string redirect;
+
+			if (!ParseCycles(stream, ncycles))
 			{
-				source->WriteNumeric(608, "%s %s :Invalid join/part spam parameter", source->nick.c_str(), chan->name.c_str());
+				source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, 'cycles' needs to be between 2 and 20.",
+					source->nick.c_str(), chan->name.c_str(), GetModeChar(), parameter.c_str());
 				return MODEACTION_DENY;
 			}
-
-			unsigned int ncycles = ConvToInt(parameter.substr(0, colon));
-			unsigned int nsecs = ConvToInt(parameter.substr(colon+1));
-
-			if (ncycles < 2 || nsecs < 1)
+			if (!ParseSeconds(stream, nsecs) || !ParseSeconds(stream, nblock))
 			{
-				source->WriteNumeric(608, "%s %s :Invalid join/part spam parameter", source->nick.c_str(), chan->name.c_str());
+				source->WriteNumeric(ERR_INVALIDMODEPARAM, "%s %s %c %s :Invalid join/part spam mode parameter, 'duration' and 'block time' need to be between 1 and 43200.",
+					source->nick.c_str(), chan->name.c_str(), GetModeChar(), parameter.c_str());
 				return MODEACTION_DENY;
 			}
+			// Error message is sent from ParseRedirect()
+			if (!ParseRedirect(stream, redirect, source, chan))
+				return MODEACTION_DENY;
 
 			joinpartspamsettings* jpss = ext.get(chan);
-			if (jpss && ncycles == jpss->cycles && nsecs == jpss->secs)
+			if (jpss && ncycles == jpss->cycles && nsecs == jpss->secs && nblock == jpss->block && redirect == jpss->redirect)
 				return MODEACTION_DENY;
 
-			ext.set(chan, new joinpartspamsettings(ncycles, nsecs));
-			parameter = ConvToStr(ncycles) + ":" + ConvToStr(nsecs);
+			ext.set(chan, new joinpartspamsettings(ncycles, nsecs, nblock, redirect));
 			chan->SetModeParam(GetModeChar(), parameter);
 			return MODEACTION_ALLOW;
 		}
-		else
-		{
-			if (!chan->IsModeSet(GetModeChar()))
-				return MODEACTION_DENY;
 
-			ext.unset(chan);
-			chan->SetModeParam(GetModeChar(), "");
-			return MODEACTION_ALLOW;
-		}
+		if (!chan->IsModeSet(GetModeChar()))
+			return MODEACTION_DENY;
+
+		ext.unset(chan);
+		chan->SetModeParam(GetModeChar(), "");
+		return MODEACTION_ALLOW;
 	}
 };
 
 class ModuleJoinPartSpam : public Module
 {
+	SimpleExtItem<joinpartspamsettings> ext;
+	bool allowredirect;
+	bool freeredirect;
 	JoinPartSpam jps;
 
  public:
 	ModuleJoinPartSpam()
-		: jps(this)
+		: ext("joinpartspam", this)
+		, allowredirect(false)
+		, freeredirect(false)
+		, jps(this, ext, allowredirect, freeredirect)
 	{
 	}
 
 	void init()
 	{
-		ServerInstance->Modules->AddService(jps);
-		ServerInstance->Modules->AddService(jps.ext);
-		Implementation eventlist[] = { I_OnUserPreJoin, I_OnUserJoin };
+		OnRehash(NULL);
+		ServiceProvider* servicelist[] = { &ext, &jps };
+		ServerInstance->Modules->AddServices(servicelist, sizeof(servicelist)/sizeof(ServiceProvider*));
+		Implementation eventlist[] = { I_OnRehash, I_OnUserPreJoin, I_OnUserJoin };
 		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
 	}
 
 	void Prioritize()
 	{
-		/* Let bans, etc. stop the join first */
+		// Let bans, etc. stop the join first
 		ServerInstance->Modules->SetPriority(this, I_OnUserPreJoin, PRIORITY_LAST);
-		ServerInstance->Modules->SetPriority(this, I_OnUserJoin, PRIORITY_LAST);
 	}
 
-	/* Stop the join and clear the user's counter if they've hit the limit */
+	void OnRehash(User*)
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("joinpartspam");
+		allowredirect = tag->getBool("allowredirect");
+		freeredirect = tag->getBool("freeredirect");
+	}
+
+	// Stop the join and clear the user's counter if they've hit the limit
 	ModResult OnUserPreJoin(User* user, Channel* chan, const char* cname, std::string& privs, const std::string& keygiven)
 	{
 		if (!chan || !chan->IsModeSet(jps.GetModeChar()))
@@ -196,27 +347,34 @@ class ModuleJoinPartSpam : public Module
 		if (IS_OPER(user))
 			return MOD_RES_PASSTHRU;
 
-		joinpartspamsettings* jpss = jps.ext.get(chan);
-		if (jpss)
-		{
-			const std::string& mask(user->MakeHost());
-			if (jpss->zapme(mask))
-			{
-				std::vector<std::string> parameters;
-				parameters.push_back(chan->name);
-				parameters.push_back("+b");
-				parameters.push_back(user->MakeWildHost());
-				ServerInstance->SendGlobalMode(parameters, ServerInstance->FakeClient);
+		joinpartspamsettings* jpss = ext.get(chan);
+		if (!jpss)
+			return MOD_RES_PASSTHRU;
 
-				user->WriteNumeric(474, "%s %s :Channel join/part spam triggered (limit is %u cycles in %u secs)", user->nick.c_str(), chan->name.c_str(), jpss->cycles, jpss->secs);
-				return MOD_RES_DENY;
-			}
+		const std::string& mask(user->MakeHost());
+
+		if (jpss->isblocked(mask))
+		{
+			user->WriteNumeric(RPL_CHANBLOCKED, "%s %s :Channel join/part spam triggered (limit is %u cycles in %u secs). Please try again later.",
+				user->nick.c_str(), chan->name.c_str(), jpss->cycles, jpss->secs);
+			return MOD_RES_DENY;
+		}
+		else if (jpss->zapme(mask))
+		{
+			// The user is now in the blocked list, deny the join, and if
+			// redirect is wanted and allowed, we join the user to that channel.
+			user->WriteNumeric(RPL_CHANBLOCKED, "%s %s :Channel join/part spam triggered (limit is %u cycles in %u secs). Please try again in %u seconds.",
+				user->nick.c_str(), chan->name.c_str(), jpss->cycles, jpss->secs, jpss->block);
+
+			if (allowredirect && !jpss->redirect.empty())
+				Channel::JoinUser(user, jpss->redirect.c_str(), false, "", false, ServerInstance->Time());
+			return MOD_RES_DENY;
 		}
 
 		return MOD_RES_PASSTHRU;
 	}
 
-	/* Only count successful joins */
+	// Only count successful joins
 	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& except)
 	{
 		if (sync)
@@ -226,7 +384,7 @@ class ModuleJoinPartSpam : public Module
 		if (IS_OPER(memb->user))
 			return;
 
-		joinpartspamsettings* jpss = jps.ext.get(memb->chan);
+		joinpartspamsettings* jpss = ext.get(memb->chan);
 		if (jpss)
 		{
 			const std::string& mask(memb->user->MakeHost());
@@ -236,7 +394,7 @@ class ModuleJoinPartSpam : public Module
 
 	Version GetVersion()
 	{
-		return Version("Provides channel mode +" + ConvToStr(jps.GetModeChar()) + " for banning Join/Part spammers.");
+		return Version("Provides channel mode +" + ConvToStr(jps.GetModeChar()) + " for blocking Join/Part spammers.", VF_OPTCOMMON);
 	}
 };
 


### PR DESCRIPTION
* Changed mode to `+x` as it appears unused so far, solves conflicts with m_blockhighlight
* Block the user from joining for a duration instead of setting a ban
* Channel redirect no longer relies on another module (banredirect)
* Block duration and channel redirect are per-channel instead of network configured
* Config option of 'allowredirect', which defaults to no.
* Config option of 'freeredirect', to skip the halfop+ check for the redirect channel. Defaults to no.

I've only quickly tested this to function correctly (parses settings, blocks joins, redirects).
@KoraggKnightWolf I'd highly appreciate some testing of this if you're willing.