### PR TITLE
Create m_autooper.cpp

### DIFF
--- a/2.0/m_autooper.cpp
+++ b/2.0/m_autooper.cpp
@@ -1,0 +1,52 @@
+/*
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* $ModAuthor: Sebastian Nielsen */
+/* $ModAuthorMail: sebastian@sebbe.eu */
+/* $ModDesc: Adds a opertype option to connect blocks so operators can get autologged in via IP */
+/* $ModDepends: core 2.0 */
+/* $ModConfig: Within connect block: opertype="OPER TYPE HERE" */
+
+
+#include "inspircd.h"
+
+class ModuleAutoOper : public Module
+{
+public:
+        void init()
+        {
+                Implementation eventlist[] = { I_OnUserConnect };
+                ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+        }
+
+        void OnUserConnect(LocalUser* user)
+        {
+                ConfigTag* tag = user->MyClass->config;
+                std::string opertype = tag->getString("opertype");
+
+                if (opertype.empty())
+                        return;
+
+                OperIndex::iterator opit = ServerInstance->Config->oper_blocks.find(" " + opertype);
+                if (opit == ServerInstance->Config->oper_blocks.end())
+                {
+                        ServerInstance->Logs->Log("m_autooper", DEFAULT, "m_autooper: Oper type %s in connect block %s not found", opertype.c_str(), user->MyClass->name.c_str());
+                        return;
+                }
+                user->Oper(opit->second);
+        }
+
+        Version GetVersion()
+        {
+                return Version("Adds a opertype option to connect blocks so operators can get autologged in via IP");
+        }
+};
+
+MODULE_INIT(ModuleAutoOper)


### PR DESCRIPTION
I want to contribute with this module into inspircd-extras. 

What it does:It adds a "opertype" option to connect block, example:
<connect allow="192.168.0.0/16" name="localoperators" timeout="60" flood="40" threshold="1" pingfreq="120" sendq="262144" recvq="8192" localmax="10" globalmax="10" opertype="NetAdmin">

You simple define a connect block extra for each IP/network you want to give oper status, and they gain oper status automatically upon connect. 

If a connect block has no opertype value, user matching this will not get opered up.

The good with this module, is that all parsing and interpretation of IPs/CIDR masks is done in core with well-proven code, which means theres no security risk in this module that would allow an unauthorized user to gain oper status via for example quirks in IPs/CIDR parsing code. (unless the server admin is stupid and writes something like <connect allow="*" opertype="NetAdmin"> but then he has itself to blame for giving everyone Oper status)