### PR TITLE
Add module which prevents a lower rank from removing a listmode entry set by a higher rank

### DIFF
--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -96,7 +96,8 @@ class ModuleBanprotect : public Module
 			return MOD_RES_PASSTHRU;
 		}
 
-		if (adding) {
+		if (adding)
+		{
 			banp->addrank(mode, param, transmitter->getRank());
 			return MOD_RES_PASSTHRU;
 		}

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -24,7 +24,8 @@ class Banprotector
 	void addrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
 		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
-		banrank[fullban] = rank;
+		if (!banrank[fullban])
+			banrank[fullban] = rank;
 	}
 
 	bool checkrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -23,27 +23,51 @@ class Banprotector
 
 	void addrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
-		if (!banrank[modeparam][banparam])
-			banrank[modeparam][banparam] = rank;
+		std::map<char, std::map<std::string, unsigned int>>::iterator obindex;
+		std::map<std::string, unsigned int> innerban;
+		std::map<std::string, unsigned int>::iterator ibindex;
+		obindex = banrank.find(modeparam);
+		if (obindex != banrank.end()) {
+			innerban = obindex->second;
+			ibindex = innerban.find(banparam);
+			if (ibindex != innerban.end())
+				return;
+		}
+		banrank[modeparam][banparam] = rank;
 	}
 
 	bool checkrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
-		if (!banrank[modeparam][banparam])
-			return true;
-		if (banrank[modeparam][banparam] > rank)
-			return false;
+		std::map<char, std::map<std::string, unsigned int>>::iterator obindex;
+		std::map<std::string, unsigned int> innerban;
+		std::map<std::string, unsigned int>::iterator ibindex;
+		obindex = banrank.find(modeparam);
+		if (obindex != banrank.end()) {
+			innerban = obindex->second;
+			ibindex = innerban.find(banparam);
+			if (ibindex == innerban.end())
+				return true;
+			if (ibindex->second > rank)
+				return false;
+		}
 		return true;
 	}
 
 	void delrank(const char& modeparam, const std::string& banparam)
 	{
-		std::map<std::string, unsigned int> innerban = banrank[modeparam];
+		std::map<char, std::map<std::string, unsigned int>>::iterator obindex;
+		std::map<std::string, unsigned int> innerban;
 		std::map<std::string, unsigned int>::iterator removeindex;
-		removeindex = innerban.find(banparam);
-		if (removeindex != innerban.end())
-			innerban.erase(removeindex);
+		obindex = banrank.find(modeparam);
+		if (obindex != banrank.end()) {
+			innerban = obindex->second;
+			removeindex = innerban.find(banparam);
+			if (removeindex != innerban.end())
+				innerban.erase(removeindex);
+				banrank[modeparam] = innerban;
+		}
 	}
+
 };
 
 class ModuleBanprotect : public Module
@@ -76,7 +100,7 @@ class ModuleBanprotect : public Module
 		if (!mh)
 			return MOD_RES_PASSTHRU;
 
-		if (!mh->IsListMode())
+		if (!mh->IsListMode() || mh->GetPrefixRank() > 0)
 			return MOD_RES_PASSTHRU;
 
 		Banprotector* banp = ext.get(chan);

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -63,11 +63,12 @@ class Banprotector
 			innerban = obindex->second;
 			removeindex = innerban.find(banparam);
 			if (removeindex != innerban.end())
+			{
 				innerban.erase(removeindex);
 				banrank[modeparam] = innerban;
+			}
 		}
 	}
-
 };
 
 class ModuleBanprotect : public Module

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -1,0 +1,112 @@
+/*
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* $ModAuthor: Sebastian Nielsen */
+/* $ModAuthorMail: sebastian@sebbe.eu */
+/* $ModDesc: Prevents a lower rank from removing a listmode item set by a higher rank */
+/* $ModDepends: core 2.0 */
+
+#include "inspircd.h"
+
+class Banprotector
+{
+ public:
+	std::map<std::string, unsigned int> banrank;
+	Banprotector() {}
+
+	void addrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
+	{
+		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
+		banrank[fullban] = rank;
+	}
+
+	bool checkrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
+	{
+		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
+		if (!banrank[fullban])
+			return true;
+		if (banrank[fullban] > rank)
+			return false;
+		return true;
+	}
+
+	void delrank(const char& modeparam, const std::string& banparam)
+	{
+		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
+		std::map<std::string, unsigned int>::iterator removeindex;
+		removeindex = banrank.find(fullban);
+		if (removeindex != banrank.end())
+			banrank.erase(removeindex);
+	}
+};
+
+class ModuleBanprotect : public Module
+{
+ private:
+	SimpleExtItem<Banprotector> ext;
+ public:
+	ModuleBanprotect()
+		: ext("Banprotector", this)
+	{
+	}
+
+	void init()
+	{
+		ServerInstance->Modules->AddService(ext);
+		ServerInstance->Modules->Attach(I_OnRawMode, this);
+	}
+
+	Version GetVersion()
+	{
+		return Version("Prevents a lower rank from removing a listmode item set by a higher rank");
+	}
+
+	ModResult OnRawMode(User* user, Channel* chan, const char mode, const std::string &param, bool adding, int pcnt)
+	{
+		if (!chan)
+			return MOD_RES_PASSTHRU;
+
+		ModeHandler *mh = ServerInstance->Modes->FindMode(mode, MODETYPE_CHANNEL);
+		if (!mh)
+			return MOD_RES_PASSTHRU;
+
+		if (!mh->IsListMode())
+			return MOD_RES_PASSTHRU;
+
+		Banprotector* banp = ext.get(chan);
+		if (!banp)
+		{
+			ext.set(chan, new Banprotector());
+			banp = ext.get(chan);
+		}
+		
+		Membership* transmitter = chan->GetUser(user);
+		if (!transmitter)
+		{
+			if (!adding)
+				banp->delrank(mode, param);
+			return MOD_RES_PASSTHRU;
+		}
+
+		if (adding) {
+			banp->addrank(mode, param, transmitter->getRank());
+			return MOD_RES_PASSTHRU;
+		}
+		
+		if (!banp->checkrank(mode, param, transmitter->getRank()) && IS_LOCAL(user) && !IS_OPER(user) && !ServerInstance->ULine(user->server))
+		{
+			user->WriteNumeric(ERR_CHANOPRIVSNEEDED, "%s %s : You need a privilege equal or higher than the person who set the entry, to remove it.", user->nick.c_str(), chan->name.c_str());
+			return MOD_RES_DENY;
+		}
+		banp->delrank(mode, param);
+		return MOD_RES_PASSTHRU;
+	}
+};
+MODULE_INIT(ModuleBanprotect)

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -18,33 +18,31 @@
 class Banprotector
 {
  public:
-	std::map<std::string, unsigned int> banrank;
+	std::map<char, std::map<std::string, unsigned int>> banrank;
 	Banprotector() {}
 
 	void addrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
-		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
-		if (!banrank[fullban])
-			banrank[fullban] = rank;
+		if (!banrank[modeparam][banparam])
+			banrank[modeparam][banparam] = rank;
 	}
 
 	bool checkrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
-		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
-		if (!banrank[fullban])
+		if (!banrank[modeparam][banparam])
 			return true;
-		if (banrank[fullban] > rank)
+		if (banrank[modeparam][banparam] > rank)
 			return false;
 		return true;
 	}
 
 	void delrank(const char& modeparam, const std::string& banparam)
 	{
-		std::string fullban = ConvToStr(modeparam) + "%" + ConvToStr(banparam);
+		std::map<std::string, unsigned int> innerban = banrank[modeparam];
 		std::map<std::string, unsigned int>::iterator removeindex;
-		removeindex = banrank.find(fullban);
-		if (removeindex != banrank.end())
-			banrank.erase(removeindex);
+		removeindex = innerban.find(banparam);
+		if (removeindex != innerban.end())
+			innerban.erase(removeindex);
 	}
 };
 

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -23,13 +23,10 @@ class Banprotector
 
 	void addrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
-		std::map<char, std::map<std::string, unsigned int>>::iterator obindex;
-		std::map<std::string, unsigned int> innerban;
-		std::map<std::string, unsigned int>::iterator ibindex;
-		obindex = banrank.find(modeparam);
+		std::map<char, std::map<std::string, unsigned int>>::iterator obindex = banrank.find(modeparam);
 		if (obindex != banrank.end()) {
-			innerban = obindex->second;
-			ibindex = innerban.find(banparam);
+			std::map<std::string, unsigned int> innerban = obindex->second;
+			std::map<std::string, unsigned int>::iterator ibindex = innerban.find(banparam);
 			if (ibindex != innerban.end())
 				return;
 		}
@@ -38,13 +35,10 @@ class Banprotector
 
 	bool checkrank(const char& modeparam, const std::string& banparam, const unsigned int& rank)
 	{
-		std::map<char, std::map<std::string, unsigned int>>::iterator obindex;
-		std::map<std::string, unsigned int> innerban;
-		std::map<std::string, unsigned int>::iterator ibindex;
-		obindex = banrank.find(modeparam);
+		std::map<char, std::map<std::string, unsigned int>>::iterator obindex = banrank.find(modeparam);
 		if (obindex != banrank.end()) {
-			innerban = obindex->second;
-			ibindex = innerban.find(banparam);
+			std::map<std::string, unsigned int> innerban = obindex->second;
+			std::map<std::string, unsigned int>::iterator ibindex = innerban.find(banparam);
 			if (ibindex == innerban.end())
 				return true;
 			if (ibindex->second > rank)
@@ -55,13 +49,10 @@ class Banprotector
 
 	void delrank(const char& modeparam, const std::string& banparam)
 	{
-		std::map<char, std::map<std::string, unsigned int>>::iterator obindex;
-		std::map<std::string, unsigned int> innerban;
-		std::map<std::string, unsigned int>::iterator removeindex;
-		obindex = banrank.find(modeparam);
+		std::map<char, std::map<std::string, unsigned int>>::iterator obindex = banrank.find(modeparam);;
 		if (obindex != banrank.end()) {
-			innerban = obindex->second;
-			removeindex = innerban.find(banparam);
+			std::map<std::string, unsigned int> innerban = obindex->second;
+			std::map<std::string, unsigned int>::iterator removeindex = innerban.find(banparam);
 			if (removeindex != innerban.end())
 			{
 				innerban.erase(removeindex);

--- a/2.0/m_banprotect.cpp
+++ b/2.0/m_banprotect.cpp
@@ -118,7 +118,7 @@ class ModuleBanprotect : public Module
 		
 		if (!banp->checkrank(mode, param, transmitter->getRank()) && IS_LOCAL(user) && !IS_OPER(user) && !ServerInstance->ULine(user->server))
 		{
-			user->WriteNumeric(ERR_CHANOPRIVSNEEDED, "%s %s : You need a privilege equal or higher than the person who set the entry, to remove it.", user->nick.c_str(), chan->name.c_str());
+			user->WriteNumeric(ERR_CHANOPRIVSNEEDED, "%s %s :You need a privilege equal or higher than the person who set the entry, to remove it.", user->nick.c_str(), chan->name.c_str());
 			return MOD_RES_DENY;
 		}
 		banp->delrank(mode, param);


### PR DESCRIPTION
This module saves the integer rank of a person who sets a listmode item (ban, exception, invex, etc), so if a lower-rank attempts to remove it, it will be rejected. This prevents for example a half-op from reversing a ban set by a op, admin or founder.

*** NOTE TO CHANSERV USERS *** Ensure your operators do not have permission to unban via ChanServ (except for themselves). Also note that any list items set through ChanServ will not be protected, unless ChanServ is present in channel (GUARD ON).

Fixes: https://github.com/inspircd/inspircd/issues/1204