### PR TITLE
Added check to prevent targeting of other oper's

### DIFF
--- a/2.0/m_pretenduser.cpp
+++ b/2.0/m_pretenduser.cpp
@@ -62,10 +62,18 @@ class CommandPretendUser : public Command
 			return CMD_FAILURE;
 		}
 
-		if (IS_OPER(u))
+		if (IS_OPER(u) && IS_OPER(user))
 		{
-			user->WriteServ("NOTICE %s :*** Cannot target an IRC operator", user->nick.c_str());
-			return CMD_FAILURE;
+			std::string level = u->oper->getConfig("level");
+			long dest_level = atol(level.c_str());
+			level = user->oper->getConfig("level");
+			long source_level = atol(level.c_str());
+
+			if (dest_level > source_level)
+			{
+				user->WriteServ("NOTICE %s :*** Cannot target IRC operator with higher level than yourself", user->nick.c_str());
+				return CMD_FAILURE;
+			}
 		}
 
 		if (IS_LOCAL(u))

--- a/2.0/m_pretenduser.cpp
+++ b/2.0/m_pretenduser.cpp
@@ -64,11 +64,8 @@ class CommandPretendUser : public Command
 
 		if (IS_OPER(u) && IS_OPER(user))
 		{
-			std::string level = u->oper->getConfig("level");
-			long dest_level = atol(level.c_str());
-			level = user->oper->getConfig("level");
-			long source_level = atol(level.c_str());
-
+			unsigned int dest_level = ConvToInt(u->oper->getConfig("level"));
+			unsigned int source_level = ConvToInt(user->oper->getConfig("level"));
 			if (dest_level > source_level)
 			{
 				user->WriteServ("NOTICE %s :*** Cannot target IRC operator with higher level than yourself", user->nick.c_str());

--- a/2.0/m_pretenduser.cpp
+++ b/2.0/m_pretenduser.cpp
@@ -62,6 +62,12 @@ class CommandPretendUser : public Command
 			return CMD_FAILURE;
 		}
 
+		if (IS_OPER(u))
+		{
+			user->WriteServ("NOTICE %s :*** Cannot target an IRC operator", user->nick.c_str());
+			return CMD_FAILURE;
+		}
+
 		if (IS_LOCAL(u))
 		{
 			if (!ServerInstance->ULine(user->server))


### PR DESCRIPTION
Added check to prevent /PRETENDUSER on Another oper, which would of course bypass any access restrictions that the executing oper has. Of course, /PRETENDUSER is a pretty serious command and should Only be given to trusted opers, but still, I think it shouldn't be possible to execute this command on Another network operator.

Imagine you dont have rights to /LOADMODULE, but have /PRETENDUSER, but you know the nick of an online oper that has the right.
And you just run /PRETENDUSER [that_oper] LOADMODULE m_restrictchans.so

Can cause pretty serious distruptions in a network.