### PR TITLE
Improvements to m_conn_require

### DIFF
--- a/2.0/m_conn_require.cpp
+++ b/2.0/m_conn_require.cpp
@@ -432,6 +432,11 @@ class ModuleConnRequire : public Module
 		if (!ud || ud->selfquit)
 			return;
 
+		// Skip users with a socket level error
+		// This ignores things like port scans, ZNC cert errors, etc.
+		if (!user->eh.getError().empty())
+			return;
+
 		bool noCap = !ud->sentcap;
 		bool noRpl = (!ctcpstring.empty() && !ud->ctcpreply);
 		bool noVer = ud->firstversionreply.empty();

--- a/2.0/m_conn_require.cpp
+++ b/2.0/m_conn_require.cpp
@@ -130,6 +130,7 @@ class ModuleConnRequire : public Module
 	const std::string::size_type len_part;
 	const std::string::size_type len_all;
 	std::string ctcpstring;
+	std::string blockmessage;
 	time_t timeout;
 
 	void SetZLine(User* user, time_t duration, const std::string& reason, const std::string& from)
@@ -206,6 +207,7 @@ class ModuleConnRequire : public Module
 		ConfigTag* tag = ServerInstance->Config->ConfValue("connrequire");
 		timeout = tag->getInt("timeout", 5);
 		ctcpstring = tag->getString("ctcpstring");
+		blockmessage = tag->getString("blockmessage");
 		std::transform(ctcpstring.begin(), ctcpstring.end(), ctcpstring.begin(), ::toupper);
 
 		tag = ServerInstance->Config->ConfValue("dualversion");
@@ -444,6 +446,10 @@ class ModuleConnRequire : public Module
 		// We didn't do it
 		if (!noCap && !noRpl && !noVer)
 			return;
+
+		// Send them a message if configured
+		if (!blockmessage.empty())
+			user->WriteServ("NOTICE %s :%s", user->nick.c_str(), blockmessage.c_str());
 
 		// Check for a match to our BanMissing and then Z-Line
 		for (std::vector<BanMissing>::const_iterator it = banmissings.begin(); it != banmissings.end(); ++it)

--- a/2.0/m_conn_require.cpp
+++ b/2.0/m_conn_require.cpp
@@ -20,9 +20,10 @@
 /* $ModAuthorMail: genius3000@g3k.solutions */
 /* $ModDesc: Allow or block connections based on multiple criteria */
 /* $ModDepends: core 2.0 */
-/* $ModConfig: <connrequire timeout="5" ctcpstring="TIME"> and see below comments */
+/* $ModConfig: <connrequire timeout="5" ctcpstring="TIME" blockmessage="Your client isn't up to spec!"> */
 
-/* <dualversion active="yes" show="yes" ban="yes" duration="7d" reason="Fix your client!">
+/* More available config tags:
+ * <dualversion active="yes" show="yes" ban="yes" duration="7d" reason="Fix your client!">
  * <badversion mask="*terrible script*" reason="Your script is terrible, bye bye!">
  * <badversion mask="xchat*" ban="yes" duration="7d" reason="Time to upgrade to Hexchat!">
  * <banmissing cap="yes" version="yes" duration="14d" reason="Upgrade your client!">
@@ -30,25 +31,27 @@
  *
  * Descriptions and defaults:
  * <connrequire >
- * timeout:	max number of seconds to hold a user while waiting for replies. Default: 5
- * ctcpstring:	a secondary CTCP request, aside from "VERSION". Default: blank
+ * timeout:        max number of seconds to hold a user while waiting for replies. Default: 5
+ * ctcpstring:     a secondary CTCP request, aside from "VERSION". Default: blank
+ * blockmessage:   a message sent to the user upon disconnect if we likely caused it. Default: blank
+ * disableversion: disable the CTCP "VERSION" request (leaves just CAP and ctcpstring useful). Default: no
  * <dualversion >
- * active:	controls the second "VERSION" request that blocks on mismatch. Default: no
- * show:	send a SNOTICE of the two replies when they don't match. Default: no
- * ban:		Z-Line the IP on a mismatch. Default: no
- * duration:	time string for the Z-Line duration. Default: 7d
- * reason:	used for both the block and Z-Line. Default: Fix your client!
+ * active:         controls the second "VERSION" request that blocks on mismatch. Default: no
+ * show:           send a SNOTICE of the two replies when they don't match. Default: no
+ * ban:            Z-Line the IP on a mismatch. Default: no
+ * duration:       time string for the Z-Line duration. Default: 7d
+ * reason:         used for both the block and Z-Line. Default: Fix your client!
  * <badversion >
- * mask:	wildcard mask to block/ban of an unwanted client version. Default: blank
- * ban:		Z-Line the IP on a match. Default: no
- * duration:	time string for the Z-Line duration. Default: 7d
- * reason:	used for both the block and Z-Line. Default: Upgrade your client!
+ * mask:           wildcard mask to block/ban of an unwanted client version. Default: blank
+ * ban:            Z-Line the IP on a match. Default: no
+ * duration:       time string for the Z-Line duration. Default: 7d
+ * reason:         used for both the block and Z-Line. Default: Upgrade your client!
  * <banmissing >
- * cap:		whether a lack of CAP matches this tag. Default: no
- * ctcp:	whether a lack of secondary CTCP (if enabled) reply matches this tag. Default: no
- * version:	whether a lack of VERSION reply matches this tag. Default: no
- * duration:	time string for the Z-Line duration. Default: 1d
- * reason:	used for the Z-Line. Default: Fix your client!
+ * cap:            whether a lack of CAP matches this tag. Default: no
+ * ctcp:           whether a lack of secondary CTCP (if enabled) reply matches this tag. Default: no
+ * version:        whether a lack of VERSION reply matches this tag. Default: no
+ * duration:       time string for the Z-Line duration. Default: 1d
+ * reason:         used for the Z-Line. Default: Fix your client!
  *
  * <badversion> and <banmissing> tags will be matched in the same order as they appear
  * in the config.

--- a/2.0/m_conn_require.cpp
+++ b/2.0/m_conn_require.cpp
@@ -469,7 +469,7 @@ class ModuleConnRequire : public Module
 
 	Version GetVersion()
 	{
-		return Version("Allow or block connections based on multiple criteria", VF_OPTCOMMON);
+		return Version("Allow or block connections based on multiple criteria");
 	}
 };
 


### PR DESCRIPTION
@H7-25 (I believe is the correct username here) found some minor issues/lacking features. These commits address them separately.

1. Module doesn't need to be loaded on all servers (`VF_OPTCOMMON`), it acts only on connecting users and won't cause any weirdness to not be loaded on certain servers.
2. Similar issue to the previous one, servers dedicated for a gateway may not want the VERSION request but do wish to have the module loaded for a variety of reasons. Added a config option to disable it.
3. The process used to block users from connect classes ends up with them being disconnected with the standard "Access denied by configuration." message; this is unable to be changed. Allow sending a configurable block message (generic to all scenarios).
4. While fixing the others, I noticed that a user quitting while unregistered can get themselves banned. Added a way to mark the users that self quit and don't act further on them.
5. Updated the documentation for the added options and improved the spacing.

@Cronus89 noticed another issue (rather annoyance with the SNOTICEs):
* Lots of SNOTICEs were triggered with unregistered users, but nothing was actually blocking them, server-side. This looks to be port scans, some other unknown connection attempts, and likely a ZNC disconnect due to failed cert. validation. Ignoring any users with a socket level error looks to prevent all these unnecessary SNOTICEs. Any user blocked due to something in this module should have a clean server sent QUIT.