### PR TITLE
m_joinpartspam: Bug-fix and comment update

### DIFF
--- a/2.0/m_joinpartspam.cpp
+++ b/2.0/m_joinpartspam.cpp
@@ -82,8 +82,8 @@ class joinpartspamsettings
 	{
 		/* If mask isn't already tracked, set reset time
 		 * If tracked and reset time is up, reset counter and reset time
-		 * Also assume another server denied join and set ban, with a user removing
-		 * the ban if counter >= cycles, reset counter and reset time
+		 * Also assume another server blocked, with the block timing out or a
+		 * user removed it if counter >= cycles, reset counter and reset time
 		 */
 		Tracking& tracking = cycler[mask];
 


### PR DESCRIPTION
* Fix a bug/workaround of using /CYCLE to cycle the channel countless times:
  * Move most of the OnUserPreJoin code to a separate function.
  * Use this new function for both OnUserPreJoin and OnPreCommand (CYCLE).
  * CYCLE will be denied if the user is or would be blocked when joining. The NOTICE sent is similar to m_cycle's "you are banned" denial message. CYCLE will not get redirected, same as how a ban redirect won't affect it.

* Update a code comment that was missed in the rewrite from banning to blocking and later with the addition of a /INVITE block removal function. 