### PR TITLE
m_conn_require: fix backwards if condition

### DIFF
--- a/2.0/m_conn_require.cpp
+++ b/2.0/m_conn_require.cpp
@@ -278,7 +278,7 @@ class ModuleConnRequire : public Module
 	ModResult OnCheckReady(LocalUser* user)
 	{
 		// Allow user to be held here for up to 'timeout' seconds
-		if (user->signon + timeout > ServerInstance->Time())
+		if (user->signon + timeout <= ServerInstance->Time())
 			return MOD_RES_PASSTHRU;
 
 		UserData* ud = userdata.get(user);


### PR DESCRIPTION
This is what causes the mystery `Registration timeout`, as it currently only holds the connection after `user->signon + timeout` has passed. Easy fix :smile: