### PR TITLE
Add module for snomasks p and P (User PMs)

### DIFF
--- a/2.0/m_userpm.cpp
+++ b/2.0/m_userpm.cpp
@@ -1,0 +1,85 @@
+/* This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "inspircd.h"
+
+/* $ModAuthor: Sebastian Nielsen */
+/* $ModAuthorMail: sebastian@sebbe.eu */
+/* $ModDesc: Provides snomasks p and P to which notices about PMs are sent */
+/* $ModDepends: core 2.0 */
+/* $ModConfig: Optional: <userpm ignoreuline="no" ignoreoper="no" expandnicks="0/1/2">, 0 = nick only, 1 = full + cloak, 2 = full */
+
+class ModuleUserPM : public Module
+{
+ private:
+ 	bool IgnoreUline;
+	bool IgnoreOper;
+	int ExpandNicks;
+ public:
+	void init()
+	{
+		ServerInstance->SNO->EnableSnomask('p', "USERPM");
+		Implementation eventlist[] = { I_OnUserMessage, I_OnUserNotice, I_OnRehash };
+		ServerInstance->Modules->Attach(eventlist, this, sizeof(eventlist)/sizeof(Implementation));
+		OnRehash(NULL);
+	}
+
+	Version GetVersion()
+	{
+		return Version("Provides snomasks p and P to which notices about PMs are sent");
+	}
+
+	void OnRehash(User *user)
+	{
+		ConfigTag* conftag = ServerInstance->Config->ConfValue("userpm");
+		this->IgnoreUline = conftag->getBool("ignoreuline", false);
+		this->IgnoreOper = conftag->getBool("ignoreoper", false);
+		this->ExpandNicks = conftag->getInt("expandnicks", 0);
+	}
+
+	void OnUserMessage(User *user, void *dest, int targettype, const std::string &pm, char status, const CUList &except)
+	{
+		if ( (targettype != TYPE_USER) || !IS_LOCAL(user) )
+		{
+			return;
+		}
+		User *duser = (User *)dest;
+		if (this->IgnoreUline && ( ServerInstance->ULine(user->server) || ServerInstance->ULine(duser->server) ))
+		{
+			return;
+		}
+		if (this->IgnoreOper && ( IS_OPER(user) || IS_OPER(duser) ))
+		{
+			return;
+		}
+		if (this->ExpandNicks == 0)
+		{
+			ServerInstance->SNO->WriteGlobalSno('p', "<%s>,<%s>: %s", user->nick.c_str(), duser->nick.c_str(), pm.c_str());
+		}
+		else
+		{
+			if (this->ExpandNicks == 1)
+			{
+				ServerInstance->SNO->WriteGlobalSno('p', "<%s!%s@%s>,<%s!%s@%s>: %s", user->nick.c_str(), user->ident.c_str(), user->dhost.c$
+			}
+			else
+			{
+				ServerInstance->SNO->WriteGlobalSno('p', "<%s!%s@%s>,<%s!%s@%s>: %s", user->nick.c_str(), user->ident.c_str(), user->host.c_$
+			}
+		}
+	}
+
+	void OnUserNotice(User *user, void *dest, int targettype, const std::string &pm, char status, const CUList &except)
+	{
+		OnUserMessage(user,dest,targettype,pm,status,except);
+	}
+};
+
+MODULE_INIT(ModuleUserPM)

--- a/2.0/m_userpm.cpp
+++ b/2.0/m_userpm.cpp
@@ -67,11 +67,11 @@ class ModuleUserPM : public Module
 		{
 			if (this->ExpandNicks == 1)
 			{
-				ServerInstance->SNO->WriteGlobalSno('p', "<%s!%s@%s>,<%s!%s@%s>: %s", user->nick.c_str(), user->ident.c_str(), user->dhost.c$
+				ServerInstance->SNO->WriteGlobalSno('p', "<%s!%s@%s>,<%s!%s@%s>: %s", user->nick.c_str(), user->ident.c_str(), user->dhost.c_str(), duser->nick.c_str(), duser->ident.c_str(), duser->dhost.c_str(), pm.c_str() );
 			}
 			else
 			{
-				ServerInstance->SNO->WriteGlobalSno('p', "<%s!%s@%s>,<%s!%s@%s>: %s", user->nick.c_str(), user->ident.c_str(), user->host.c_$
+				ServerInstance->SNO->WriteGlobalSno('p', "<%s!%s@%s>,<%s!%s@%s>: %s", user->nick.c_str(), user->ident.c_str(), user->host.c_str(), duser->nick.c_str(), duser->ident.c_str(), duser->host.c_str(), pm.c_str() );
 			}
 		}
 	}


### PR DESCRIPTION
I got a request for creating this module from a server owner on Another network via email, since this owner had large problems with abuse over PMs that fly under the radar.
This module allows server administrators (and opers) to read PMs through Snomasks p and P. (p = local PMs, P = remote PMs).
This allows server administrators to enforce network usage rules across PMs.
Note that on larger networks this module might get spammy, why I recommend instead redirecting the output to a channel like #userpm using m_chanlog.so, and don't forget +O on that channel.

Config:
`<userpm ignoreuline="yes/no" ignoreoper="yes/no" expandnicks="0/1/2">`

ignoreuline="yes"/"no": This will make the module ignore PMs to/from u-lined servers if set. This config is HIGHLY RECOMMENDED to set to "yes" to avoid NickServ/ChanServ/OperServ passwords from ending up in the wrong places. However, for some networks it might be useful to set this to "no" to make it possible to log excessive login attempts to NickServ/ChanServ/OperServ and use a bot to issue Z-lines/G-lines/etc.

ignoreoper="yes"/"no": This will make the module ignore PMs to/from opers. In some cases it can be a good idea to set it to "yes" to avoid PMs to/from Opers from ending up as server notices, but in some cases it can be useful to see other oper's PMs (for example if an oper does an decision in favor for a user, for example "Yes you can bring your own bot here", it could be useful for a network at a large to be able to see this decision and prevent other oper's from intervening thinking the user did not have permission)

expandnicks="0/1/2":
This config allows you to set how nicks are displayed in the server notices. If you set this to 0, only the nick is shown, for example:
`USERPM: <Source>,<Target>: Content of PM`

If you set it to 1, it will display the nicks in expanded nick!ident@host format, but will leave host cloaked, if you have the cloak module activated, for example:
`USERPM: <Source!Source@network-gs7.9vf.8gbi23.IP>,<Target!Target@network-h8j.2dv.2nbjkl.IP>: Content of PM`

If you set it to 2, it will display it in uncloaked format, for example:
`USERPM: <Source!Source@user1.someisp.com>,<Target!Target@user2.anotherisp.com>: Content of PM`

The module displays everything in a easy-to-parseable format so its also possible to create bots that act on PM content.
To disable the possibility to use OTR encryption, use a censor/filter module to disable the string "?OTR" to be sent.

Note that this module can be a Little controversial in the IRC World, why I recommend to be responsible when using this module on your server, and not allowing every oper to use this module. More about restricting usage to certain opers later down.

To restrict which opers that are able to read PMs through snomasks, I recommend disabling mode "s" in server config (so no opers can use SNOMASKS), and instead provide SNOMASK functionality through separate +O channels using m_chanlog.so, where you can through channel config restrict which opers have access (for example via bans, exceptions, invites and channel keys), which allows diverse access condition for each snomask.