### PR TITLE
2.0/m_antirandom: Fix unguarded if block

### DIFF
--- a/2.0/m_antirandom.cpp
+++ b/2.0/m_antirandom.cpp
@@ -813,10 +813,12 @@ class ModuleAntiRandom : public Module
 
 		tmp = conftag->getString("banduration");
 		if (!tmp.empty())
+		{
 			this->BanDuration = ServerInstance->Duration(tmp.c_str());
 			// Sanity check
 			if ((int)this->BanDuration <= 0)
 				this->BanDuration = 1;
+		}
 		else
 			this->BanDuration = 86400; // One day.
 


### PR DESCRIPTION
The newer GCC (`gcc (Ubuntu 7.3.0-16ubuntu3) 7.3.0`) on Ubuntu 18.04 caught this and warned.