### PR TITLE
m_conn_require: Improve the handling in OnPreCommand

### DIFF
--- a/2.0/m_conn_require.cpp
+++ b/2.0/m_conn_require.cpp
@@ -414,7 +414,7 @@ class ModuleConnRequire : public Module
 	void OnUserInit(LocalUser* user)
 	{
 		// Initialize their UserData and send the CTCP request(s)
-		UserData ud;
+		UserData* ud = new UserData;
 		userdata.set(user, ud);
 
 		if (!disableversion)


### PR DESCRIPTION
Currently the handling in OnPreCommand is eating any `CTCP NOTICE` reply, when it really shouldn't. I've reworked things so only expected `VERSION` or configured `CTCP` replies are processed and ate. Granted, this could still get mixed with another module requesting the same, but both should be capable of accepting one-after-another without issue.

* Noticed the initialization of the per user UserData object was incorrect, fixed that so I could set the expect{version,ctcp} bools when first sending the requests.
* Moved 'zapped' from another ExtItem to a bool in UserData and no longer send the block message or check for 'banmissing' when we've already 'zapped' the user.
* Within OnPreCommand
  * Check for UserData object first
  * Check for the expectation of a reply before processing one
  * Default return to PASSTHRU instead of DENY