### PR TITLE
Update to m_xlinetools - bug fix and improvements

### DIFF
--- a/2.0/m_xlinetools.cpp
+++ b/2.0/m_xlinetools.cpp
@@ -275,6 +275,8 @@ class CommandXBase : public SplitCommand
 	{
 		total += xlines->size();
 		LookupIter safei;
+		bool negate;
+		bool match;
 
 		for (LookupIter i = xlines->begin(); i != xlines->end(); )
 		{
@@ -284,24 +286,27 @@ class CommandXBase : public SplitCommand
 			XLine* xline = i->second;
 
 			// CIDR and glob mask matching, with negation
-			if ((args.mask[0] == '!' && InspIRCd::MatchCIDR(xline->Displayable(), args.mask.substr(1))) ||
-			    (args.mask[0] != '!' && !InspIRCd::MatchCIDR(xline->Displayable(), args.mask)))
+			negate = args.mask[0] == '!';
+			match = InspIRCd::MatchCIDR(xline->Displayable(), (negate ? args.mask.substr(1) : args.mask));
+			if ((negate && match) || (!negate && !match))
 			{
 				i = safei;
 				continue;
 			}
 
 			// Glob reason matching, with negation
-			if ((args.reason[0] == '!' && InspIRCd::Match(xline->reason, args.reason.substr(1))) ||
-			    (args.reason[0] != '!' && !InspIRCd::Match(xline->reason, args.reason)))
+			negate = args.reason[0] == '!';
+			match = InspIRCd::Match(xline->reason, (negate ? args.reason.substr(1) : args.reason));
+			if ((negate && match) || (!negate && !match))
 			{
 				i = safei;
 				continue;
 			}
 
 			// Glob source matching, with negation
-			if ((args.source[0] == '!' && InspIRCd::Match(xline->source, args.source.substr(1))) ||
-			    (args.source[0] != '!' && !InspIRCd::Match(xline->source, args.source)))
+			negate = args.source[0] == '!';
+			match = InspIRCd::Match(xline->source, (negate ? args.source.substr(1) : args.source));
+			if ((negate && match) || (!negate && !match))
 			{
 				i = safei;
 				continue;

--- a/2.0/m_xlinetools.cpp
+++ b/2.0/m_xlinetools.cpp
@@ -18,13 +18,13 @@
 
 /* $ModAuthor: genius3000 */
 /* $ModAuthorMail: genius3000@g3k.solutions */
-/* $ModDesc: X-Line management with XCOUNT, XREMOVE, XSEARCH, and XCOPY */
+/* $ModDesc: X-line management with XCOUNT, XREMOVE, XSEARCH, and XCOPY */
 /* $ModDepends: core 2.0 */
 
 /* XCOUNT, XREMOVE, and XSEARCH are the same except for the end action:
- * XCOUNT will just return a count of matching X-Lines.
- * XREMOVE will remove the matching X-Lines and return that count.
- * XSEARCH will list the matching X-Lines and that count.
+ * XCOUNT will just return a count of matching X-lines.
+ * XREMOVE will remove the matching X-lines and return that count.
+ * XSEARCH will list the matching X-lines and that count.
  * Syntax is argument and value style "-arg=val" and is the same for each.
  * All arguments are optional:
  * -type=<xline type or *>
@@ -35,8 +35,8 @@
  * -duration=<time string> (actual set duration) Exact match, prefix '+' for longer than, or '-' for shorter than
  * -expires=<time string> (time ahead) Prefix with '+' for more than
  *
- * XCOPY copies a specified X-Line (by type and mask) to a
- * new X-Line of same type with a new mask.
+ * XCOPY copies a specified X-line (by type and mask) to a
+ * new X-line of same type with a new mask.
  * Original reason and expiry time are copied but can be
  * overridden with the 'duration' or 'reason' arguments.
  *
@@ -50,28 +50,28 @@
  * line after 'FILTER OJOIN'.
  * Find: '<helpop key="clones" ...'
  * Place just above that line:
-<helpop key="xcount" value="/XCOUNT -type=<xline type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
+<helpop key="xcount" value="/XCOUNT -type=<X-line type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
 
-Returns a count of matching X-Lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
+Returns a count of matching X-lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
 is a nick, server, or <Config>. 'Prefix your value for these 3 arguments with a '!' to negate the match. 't' is a
 time-string (seconds or 1y2w3d4h5m6s) and can be prefixed with '+' or '-' to adjust matching. All arguments are optional.">
 
-<helpop key="xremove" value="/XREMOVE -type=<xline type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
+<helpop key="xremove" value="/XREMOVE -type=<X-line type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
 
-Removes matching X-Lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
+Removes matching X-lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
 is a nick, server, or <Config>. 'Prefix your value for these 3 arguments with a '!' to negate the match. 't' is a
 time-string (seconds or 1y2w3d4h5m6s) and can be prefixed with '+' or '-' to adjust matching. All arguments are optional.
 Use /XSEARCH to test before removing.">
 
-<helpop key="xsearch" value="/XSEARCH -type=<xline type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
+<helpop key="xsearch" value="/XSEARCH -type=<X-line type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
 
-Lists matching X-Lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
+Lists matching X-lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
 is a nick, server, or <Config>. Prefix your value for these 3 arguments with a '!' to negate the match. 't' is a
 time-string (seconds or 1y2w3d4h5m6s) and can be prefixed with '+' or '-' to adjust matching. All arguments are optional.">
 
-<helpop key="xcopy" value="/XCOPY <xline type> <old mask> <new mask> [-duration=<> -reason=<>]
+<helpop key="xcopy" value="/XCOPY <X-line type> <old mask> <new mask> [-duration=<> -reason=<>]
 
-Copies the specified X-Line (if found) to a new X-Line. The original reason and expiry time
+Copies the specified X-line (if found) to a new X-line. The original reason and expiry time
 are copied unless overridden with '-duration=' or '-reason='">
 
 
@@ -227,10 +227,10 @@ namespace
 	{
 		std::string typestr;
 
-		// Core/Vendor *-Lines are single character, some -extras are two
-		// Other X-Lines look better without -Lines
+		// Core/Vendor *-lines are single character, some -extras are two
+		// Other X-lines look better without -lines
 		if (type.length() <= 2)
-			typestr = type + "-Line";
+			typestr = type + "-line";
 		else
 			typestr = type;
 
@@ -401,7 +401,7 @@ class CommandXBase : public SplitCommand
 		if (args.type == "*")
 		{
 			if (!count)
-				user->WriteServ("NOTICE %s :%s matches from all X-Line types (%s)", user->nick.c_str(), action.c_str(), criteria.c_str());
+				user->WriteServ("NOTICE %s :%s matches from all X-line types (%s)", user->nick.c_str(), action.c_str(), criteria.c_str());
 
 			std::vector<std::string> xlinetypes = ServerInstance->XLines->GetAllTypes();
 			for (std::vector<std::string>::const_iterator x = xlinetypes.begin(); x != xlinetypes.end(); ++x)
@@ -420,19 +420,19 @@ class CommandXBase : public SplitCommand
 			}
 
 			if (count)
-				user->WriteServ("NOTICE %s :%u of %u X-Lines matched (%s)", user->nick.c_str(), matched, total, criteria.c_str());
+				user->WriteServ("NOTICE %s :%u of %u X-lines matched (%s)", user->nick.c_str(), matched, total, criteria.c_str());
 			else
-				user->WriteServ("NOTICE %s :End of list, %u/%u X-Lines %s", user->nick.c_str(), matched, total, (remove ? "removed" : "matched"));
+				user->WriteServ("NOTICE %s :End of list, %u/%u X-lines %s", user->nick.c_str(), matched, total, (remove ? "removed" : "matched"));
 		}
 		else
 		{
 			std::string linetype = args.type;
 			std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
 
-			// Check for the command permission to remove X-Lines of this type
+			// Check for the command permission to remove X-lines of this type
 			if (remove && !HasPermission(user, linetype))
 			{
-				user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to remove X-Lines of type '%s'",
+				user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to remove X-lines of type '%s'",
 						   user->nick.c_str(), user->oper->NameStr(), linetype.c_str());
 				return false;
 			}
@@ -440,24 +440,24 @@ class CommandXBase : public SplitCommand
 			XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
 			if (!xlines)
 			{
-				user->WriteServ("NOTICE %s :Invalid X-Line type '%s' (or not yet used X-Line)", user->nick.c_str(), linetype.c_str());
+				user->WriteServ("NOTICE %s :Invalid X-line type '%s' (or not yet used X-line)", user->nick.c_str(), linetype.c_str());
 				return false;
 			}
 			if (xlines->empty())
 			{
-				user->WriteServ("NOTICE %s :No X-Lines of type '%s' exist", user->nick.c_str(), linetype.c_str());
+				user->WriteServ("NOTICE %s :No X-lines of type '%s' exist", user->nick.c_str(), linetype.c_str());
 				return false;
 			}
 
 			if (!count)
-				user->WriteServ("NOTICE %s :%s matches of X-Line type '%s' (%s)", user->nick.c_str(), action.c_str(), linetype.c_str(), criteria.c_str());
+				user->WriteServ("NOTICE %s :%s matches of X-line type '%s' (%s)", user->nick.c_str(), action.c_str(), linetype.c_str(), criteria.c_str());
 
 			ProcessLines(user, args, linetype, xlines, matched, total, count, remove);
 
 			if (count)
-				user->WriteServ("NOTICE %s :%u of %u X-Lines of type '%s' matched (%s)", user->nick.c_str(), matched, total, linetype.c_str(), criteria.c_str());
+				user->WriteServ("NOTICE %s :%u of %u X-lines of type '%s' matched (%s)", user->nick.c_str(), matched, total, linetype.c_str(), criteria.c_str());
 			else
-				user->WriteServ("NOTICE %s :End of list, %u/%u X-Lines of type '%s' %s", user->nick.c_str(), matched, total, linetype.c_str(), (remove ? "removed" : "matched"));
+				user->WriteServ("NOTICE %s :End of list, %u/%u X-lines of type '%s' %s", user->nick.c_str(), matched, total, linetype.c_str(), (remove ? "removed" : "matched"));
 		}
 
 		return true;
@@ -520,14 +520,14 @@ class CommandXCopy : public SplitCommand
 			}
 		}
 
-		// Lookup the X-Line matching what we were given
+		// Lookup the X-line matching what we were given
 		std::string linetype = xtype;
 		std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
 
-		// Check for the command permission to copy this type of X-Line
+		// Check for the command permission to copy this type of X-line
 		if (!HasPermission(user, linetype))
 		{
-			user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to copy an X-Line of type '%s'",
+			user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to copy an X-line of type '%s'",
 					   user->nick.c_str(), user->oper->NameStr(), linetype.c_str());
 			return CMD_FAILURE;
 		}
@@ -535,7 +535,7 @@ class CommandXCopy : public SplitCommand
 		XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
 		if (!xlines)
 		{
-			user->WriteServ("NOTICE %s :Invalid X-Line type '%s' (or not yet used X-Line)", user->nick.c_str(), linetype.c_str());
+			user->WriteServ("NOTICE %s :Invalid X-line type '%s' (or not yet used X-line)", user->nick.c_str(), linetype.c_str());
 			return CMD_FAILURE;
 		}
 
@@ -565,7 +565,7 @@ class CommandXCopy : public SplitCommand
 			return CMD_FAILURE;
 		}
 
-		// Get the needed X-Line Factory and create the new X-Line
+		// Get the needed X-line Factory and create the new X-line
 		// Snagged this method from m_xline_db
 		XLineFactory* xlf = ServerInstance->XLines->GetFactory(linetype);
 		if (!xlf)
@@ -581,11 +581,11 @@ class CommandXCopy : public SplitCommand
 			duration = (oldxline->duration == 0 ? 0 : (oldxline->set_time + oldxline->duration - ServerInstance->Time()));
 
 		const std::string& reason = (!args.reason.empty() ? args.reason : oldxline->reason);
-		const std::string expires = (duration == 0 ? "" : (", to expire on " + ServerInstance->TimeString(ServerInstance->Time() + duration)));
+		const std::string expires = (duration == 0 ? "" : (", expires on " + ServerInstance->TimeString(ServerInstance->Time() + duration)));
 
 		XLine* newxline = xlf->Generate(ServerInstance->Time(), duration, user->nick, reason, newmask);
 		if (ServerInstance->XLines->AddLine(newxline, user))
-			ServerInstance->SNO->WriteToSnoMask('x', "%s added %s %s on %s%s: %s", user->nick.c_str(),
+			ServerInstance->SNO->WriteToSnoMask('x', "%s added %s %s for %s%s: %s", user->nick.c_str(),
 				(duration == 0 ? "permanent" : "timed"), BuildTypeStr(linetype).c_str(),
 				newmask.c_str(), expires.c_str(), reason.c_str());
 		else
@@ -623,7 +623,7 @@ class ModuleXLineTools : public Module
 
 	virtual Version GetVersion()
 	{
-		return Version("X-Line management tools", VF_OPTCOMMON);
+		return Version("X-line management tools", VF_OPTCOMMON);
 	}
 };
 

--- a/2.0/m_xlinetools.cpp
+++ b/2.0/m_xlinetools.cpp
@@ -39,6 +39,9 @@
  * new X-Line of same type with a new mask.
  * Original reason and expiry time are copied but can be
  * overridden with the 'duration' or 'reason' arguments.
+ *
+ * Note: Both XCOPY and XREMOVE will check for the appropriate
+ * command permissions before acting.
  */
 
 /* Helpop Lines for the COPER section
@@ -98,166 +101,177 @@ struct Criteria
 	}
 };
 
-bool ProcessArgs(const std::vector<std::string>& params, Criteria& args)
+namespace
 {
-	if (!params.size())
-		return false;
-
-	// Track arg reason to include space separated params
-	bool argreason = false;
-
-	const std::string mtype("-type=");
-	const std::string mmask("-mask=");
-	const std::string mreason("-reason=");
-	const std::string msource("-source=");
-	const std::string msetby("-setby=");
-	const std::string mset("-set=");
-	const std::string mduration("-duration=");
-	const std::string mexpires("-expires=");
-
-	for (std::vector<std::string>::const_iterator p = params.begin(); p != params.end(); ++p)
+	bool HasPermission(LocalUser* user, std::string type)
 	{
-		const std::string param = *p;
+		if (type.length() <= 2)
+			type.append("LINE");
 
-		if (param.find(mtype) != std::string::npos)
+		return user->HasPermission(type);
+	}
+
+	bool ProcessArgs(const std::vector<std::string>& params, Criteria& args)
+	{
+		if (!params.size())
+			return false;
+
+		// Track arg reason to include space separated params
+		bool argreason = false;
+
+		const std::string mtype("-type=");
+		const std::string mmask("-mask=");
+		const std::string mreason("-reason=");
+		const std::string msource("-source=");
+		const std::string msetby("-setby=");
+		const std::string mset("-set=");
+		const std::string mduration("-duration=");
+		const std::string mexpires("-expires=");
+
+		for (std::vector<std::string>::const_iterator p = params.begin(); p != params.end(); ++p)
 		{
-			argreason = false;
-			const std::string& val(param.substr(mtype.length()));
-			args.type = (!val.empty() ? val : "*");
-		}
-		else if (param.find(mmask) != std::string::npos)
-		{
-			argreason = false;
-			const std::string& val(param.substr(mmask.length()));
-			args.mask = (!val.empty() ? val : "*");
-		}
-		else if (param.find(mreason) != std::string::npos)
-		{
-			argreason = true;
-			const std::string& val(param.substr(mreason.length()));
-			args.reason = (!val.empty() ? val : "*");
-		}
-		else if (param.find(msource) != std::string::npos)
-		{
-			argreason = false;
-			const std::string& val(param.substr(msource.length()));
-			args.source = (!val.empty() ? val : "*");
-		}
-		else if (param.find(msetby) != std::string::npos)
-		{
-			argreason = false;
-			const std::string& val(param.substr(msetby.length()));
-			args.source = (!val.empty() ? val : "*");
-		}
-		else if (param.find(mset) != std::string::npos)
-		{
-			argreason = false;
-			const std::string& val = param.substr(mset.length());
-			args.set = (ServerInstance->Duration(val) ? val : "");
-		}
-		else if (param.find(mduration) != std::string::npos)
-		{
-			argreason = false;
-			const std::string& val = param.substr(mduration.length());
-			// 0 is a special case here, to match no expires
-			if (val == "0")
-				args.duration = val;
+			const std::string param = *p;
+
+			if (param.find(mtype) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val(param.substr(mtype.length()));
+				args.type = (!val.empty() ? val : "*");
+			}
+			else if (param.find(mmask) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val(param.substr(mmask.length()));
+				args.mask = (!val.empty() ? val : "*");
+			}
+			else if (param.find(mreason) != std::string::npos)
+			{
+				argreason = true;
+				const std::string& val(param.substr(mreason.length()));
+				args.reason = (!val.empty() ? val : "*");
+			}
+			else if (param.find(msource) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val(param.substr(msource.length()));
+				args.source = (!val.empty() ? val : "*");
+			}
+			else if (param.find(msetby) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val(param.substr(msetby.length()));
+				args.source = (!val.empty() ? val : "*");
+			}
+			else if (param.find(mset) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val = param.substr(mset.length());
+				args.set = (ServerInstance->Duration(val) ? val : "");
+			}
+			else if (param.find(mduration) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val = param.substr(mduration.length());
+				// 0 is a special case here, to match no expires
+				if (val == "0")
+					args.duration = val;
+				else
+					args.duration = (ServerInstance->Duration(val) ? val : "");
+			}
+			else if (param.find(mexpires) != std::string::npos)
+			{
+				argreason = false;
+				const std::string& val = param.substr(mexpires.length());
+				args.expires = (ServerInstance->Duration(val) ? val : "");
+			}
 			else
-				args.duration = (ServerInstance->Duration(val) ? val : "");
+			{
+				if (argreason)
+					args.reason.append(" " + param);
+				else
+					return false;
+			}
 		}
-		else if (param.find(mexpires) != std::string::npos)
-		{
-			argreason = false;
-			const std::string& val = param.substr(mexpires.length());
-			args.expires = (ServerInstance->Duration(val) ? val : "");
-		}
+
+		return true;
+	}
+
+	const std::string BuildCriteriaStr(const Criteria& args)
+	{
+		std::string criteria;
+		const std::string sep(", ");
+
+		if (args.mask != "*")
+			criteria.append("Mask: " + args.mask + sep);
+		if (args.reason != "*")
+			criteria.append("Reason: " + args.reason + sep);
+		if (args.source != "*")
+			criteria.append("Source: " + args.source + sep);
+		if (!args.set.empty())
+			criteria.append("Set: " + args.set + sep);
+		if (!args.duration.empty())
+			criteria.append("Duration: " + args.duration + sep);
+		if (!args.expires.empty())
+			criteria.append("Expires: " + args.expires + sep);
+
+		if (criteria.empty())
+			criteria.append("No specific criteria");
+		// Remove trailing separator
+		else if (criteria[criteria.length() - 1] == ' ')
+			criteria.erase(criteria.length() - 2, 2);
+
+		return criteria;
+	}
+
+	const std::string BuildTypeStr(const std::string& type)
+	{
+		std::string typestr;
+
+		// Core/Vendor *-Lines are single character, some -extras are two
+		// Other X-Lines look better without -Lines
+		if (type.length() <= 2)
+			typestr = type + "-Line";
+		else
+			typestr = type;
+
+		return typestr;
+	}
+
+	// Snagged this from Anope: https://github.com/anope/anope/blob/2.0/src/misc.cpp
+	// Modified to return short text format
+	const std::string BuildDurationStr(time_t t)
+	{
+		/* We first calculate everything */
+		time_t years = t / 31536000;
+		time_t days = (t / 86400) % 365;
+		time_t hours = (t / 3600) % 24;
+		time_t minutes = (t / 60) % 60;
+		time_t seconds = (t) % 60;
+
+		if (!years && !days && !hours && !minutes)
+			return ConvToStr(seconds) + "s";
 		else
 		{
-			if (argreason)
-				args.reason.append(" " + param);
-			else
-				return false;
+			std::string buffer;
+			if (years)
+				buffer = ConvToStr(years) + "y";
+			if (days)
+				buffer += ConvToStr(days) + "d";
+			if (hours)
+				buffer += ConvToStr(hours) + "h";
+			if (minutes)
+				buffer += ConvToStr(minutes) + "m";
+			if (seconds)
+				buffer += ConvToStr(seconds) + "s";
+
+			return buffer;
 		}
 	}
-
-	return true;
 }
 
-const std::string BuildCriteriaStr(const Criteria& args)
+class CommandXBase : public SplitCommand
 {
-	std::string criteria;
-	const std::string sep(", ");
-
-	if (args.mask != "*")
-		criteria.append("Mask: " + args.mask + sep);
-	if (args.reason != "*")
-		criteria.append("Reason: " + args.reason + sep);
-	if (args.source != "*")
-		criteria.append("Source: " + args.source + sep);
-	if (!args.set.empty())
-		criteria.append("Set: " + args.set + sep);
-	if (!args.duration.empty())
-		criteria.append("Duration: " + args.duration + sep);
-	if (!args.expires.empty())
-		criteria.append("Expires: " + args.expires + sep);
-
-	if (criteria.empty())
-		criteria.append("No specific criteria");
-	// Remove trailing separator
-	else if (criteria[criteria.length() - 1] == ' ')
-		criteria.erase(criteria.length() - 2, 2);
-
-	return criteria;
-}
-
-const std::string BuildTypeStr(const std::string& type)
-{
-	std::string typestr;
-
-	// Core/Vendor *-Lines are single character, some -extras are two
-	// Other X-Lines look better without -Lines
-	if (type.length() <= 2)
-		typestr = type + "-Line";
-	else
-		typestr = type;
-
-	return typestr;
-}
-
-// Snagged this from Anope: https://github.com/anope/anope/blob/2.0/src/misc.cpp
-// Modified to return short text format
-const std::string BuildDurationStr(time_t t)
-{
-	/* We first calculate everything */
-	time_t years = t / 31536000;
-	time_t days = (t / 86400) % 365;
-	time_t hours = (t / 3600) % 24;
-	time_t minutes = (t / 60) % 60;
-	time_t seconds = (t) % 60;
-
-	if (!years && !days && !hours && !minutes)
-		return ConvToStr(seconds) + "s";
-	else
-	{
-		std::string buffer;
-		if (years)
-			buffer = ConvToStr(years) + "y";
-		if (days)
-			buffer += ConvToStr(days) + "d";
-		if (hours)
-			buffer += ConvToStr(hours) + "h";
-		if (minutes)
-			buffer += ConvToStr(minutes) + "m";
-		if (seconds)
-			buffer += ConvToStr(seconds) + "s";
-
-		return buffer;
-	}
-}
-
-class CommandXBase : public Command
-{
-	void ProcessLines(User* user, const Criteria& args, const std::string& linetype, XLineLookup* xlines, unsigned int& matched, unsigned int& total, const bool count, const bool remove)
+	void ProcessLines(LocalUser* user, const Criteria& args, const std::string& linetype, XLineLookup* xlines, unsigned int& matched, unsigned int& total, const bool count, const bool remove)
 	{
 		total += xlines->size();
 		LookupIter safei;
@@ -370,7 +384,7 @@ class CommandXBase : public Command
 		}
 	}
 
-	bool HandleCmd(User* user, const Criteria& args, Command* cmd)
+	bool HandleCmd(LocalUser* user, const Criteria& args, Command* cmd)
 	{
 		bool count = (cmd->name == "XCOUNT" ? true : false);
 		bool remove = (cmd->name == "XREMOVE" ? true : false);
@@ -387,13 +401,21 @@ class CommandXBase : public Command
 			std::vector<std::string> xlinetypes = ServerInstance->XLines->GetAllTypes();
 			for (std::vector<std::string>::const_iterator x = xlinetypes.begin(); x != xlinetypes.end(); ++x)
 			{
+				// If removing, check for the command permission for this type
+				if (remove && !HasPermission(user, *x))
+				{
+					user->WriteServ("NOTICE %s :Skipping type '%s' as oper type '%s' does not have access to remove these.",
+							   user->nick.c_str(), (*x).c_str(), user->oper->NameStr());
+					continue;
+				}
+
 				XLineLookup* xlines = ServerInstance->XLines->GetAll(*x);
 				if (xlines)
 					ProcessLines(user, args, *x, xlines, matched, total, count, remove);
 			}
 
 			if (count)
-				user->WriteServ("NOTICE %s :%u of %u all X-Lines matched (%s)", user->nick.c_str(), matched, total, criteria.c_str());
+				user->WriteServ("NOTICE %s :%u of %u X-Lines matched (%s)", user->nick.c_str(), matched, total, criteria.c_str());
 			else
 				user->WriteServ("NOTICE %s :End of list, %u/%u X-Lines %s", user->nick.c_str(), matched, total, (remove ? "removed" : "matched"));
 		}
@@ -401,6 +423,14 @@ class CommandXBase : public Command
 		{
 			std::string linetype = args.type;
 			std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
+
+			// Check for the command permission to remove X-Lines of this type
+			if (remove && !HasPermission(user, linetype))
+			{
+				user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to remove X-Lines of type '%s'",
+						   user->nick.c_str(), user->oper->NameStr(), linetype.c_str());
+				return false;
+			}
 
 			XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
 			if (!xlines)
@@ -429,13 +459,13 @@ class CommandXBase : public Command
 	}
 
  public:
-	CommandXBase(Module* Creator, const std::string& cmdname) : Command(Creator, cmdname, 1)
+	CommandXBase(Module* Creator, const std::string& cmdname) : SplitCommand(Creator, cmdname, 1)
 	{
 		syntax = "-type=<type|*> -mask=[!]<> -reason=[!]<> -source=[!]<> -set=[-]<time> -duration=[-+]<time> -expires=[+]<time>";
 		flags_needed = 'o';
 	}
 
-	CmdResult Handle(const std::vector<std::string>& parameters, User* user)
+	CmdResult HandleLocal(const std::vector<std::string>& parameters, LocalUser* user)
 	{
 		if (parameters[0][0] != '-' || parameters[0].find('=') == std::string::npos)
 		{
@@ -459,16 +489,16 @@ class CommandXBase : public Command
 	}
 };
 
-class CommandXCopy : public Command
+class CommandXCopy : public SplitCommand
 {
  public:
-	CommandXCopy(Module* Creator) : Command(Creator, "XCOPY", 3)
+	CommandXCopy(Module* Creator) : SplitCommand(Creator, "XCOPY", 3)
 	{
 		syntax = "<xline type> <old mask> <new mask> [-duration=<> -reason=<>]";
 		flags_needed = 'o';
 	}
 
-	CmdResult Handle(const std::vector<std::string>& parameters, User* user)
+	CmdResult HandleLocal(const std::vector<std::string>& parameters, LocalUser* user)
 	{
 		const std::string& xtype = parameters[0];
 		const std::string& oldmask = parameters[1];
@@ -488,6 +518,14 @@ class CommandXCopy : public Command
 		// Lookup the X-Line matching what we were given
 		std::string linetype = xtype;
 		std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
+
+		// Check for the command permission to copy this type of X-Line
+		if (!HasPermission(user, linetype))
+		{
+			user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to copy an X-Line of type '%s'",
+					   user->nick.c_str(), user->oper->NameStr(), linetype.c_str());
+			return CMD_FAILURE;
+		}
 
 		XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
 		if (!xlines)

--- a/2.0/m_xlinetools.cpp
+++ b/2.0/m_xlinetools.cpp
@@ -30,7 +30,7 @@
  * -type=<xline type or *>
  * -mask=<mask> CIDR supported>
  * -reason=<reason> Spaces allowed
- * -source=<source> Nick, server, or "<Config>"
+ * -source=<source> Nick, server, or "<Config>" ("setby" can be used instead of "source")
  * -set=<time string> (time ago) Prefix with '-' for less than
  * -duration=<time string> (actual set duration) Exact match, prefix '+' for longer than, or '-' for shorter than
  * -expires=<time string> (time ahead) Prefix with '+' for more than
@@ -110,6 +110,7 @@ bool ProcessArgs(const std::vector<std::string>& params, Criteria& args)
 	const std::string mmask("-mask=");
 	const std::string mreason("-reason=");
 	const std::string msource("-source=");
+	const std::string msetby("-setby=");
 	const std::string mset("-set=");
 	const std::string mduration("-duration=");
 	const std::string mexpires("-expires=");
@@ -140,6 +141,12 @@ bool ProcessArgs(const std::vector<std::string>& params, Criteria& args)
 		{
 			argreason = false;
 			const std::string& val(param.substr(msource.length()));
+			args.source = (!val.empty() ? val : "*");
+		}
+		else if (param.find(msetby) != std::string::npos)
+		{
+			argreason = false;
+			const std::string& val(param.substr(msetby.length()));
 			args.source = (!val.empty() ? val : "*");
 		}
 		else if (param.find(mset) != std::string::npos)


### PR DESCRIPTION
1. Add `XCOUNT`
   * Simply just counts the number of matched lines.
   * Re-order and rename some functions.
   * Documentation update
2. Improve the matching logic
   * Cut back repetitive calls to Match() and makes the code a little cleaner.
3. Bug-fix: `XCOPY` and `XREMOVE` could be used by any oper regardless of command permissions
   * Check for appropriate command permission before allowing.
   * Switched to local only command handlers to accommodate this.
   * Moved common functions inside an anonymous namespace.
4. Add `setby` as an alias for `source` as it sounds more familiar.