### PR TITLE
Fix sslmodeuser to allow conn_umodes to set it on connect.

### DIFF
--- a/2.0/m_sslmodeuser.cpp
+++ b/2.0/m_sslmodeuser.cpp
@@ -55,8 +55,19 @@ class SSLModeUser : public ModeHandler
 		{
 			if (!dest->IsModeSet(this->GetModeChar()))
 			{
-				if(!IsSSLUser(creator, dest))
-					return MODEACTION_DENY;
+				// Special case for local users, so conn_umodes works if intended.
+				LocalUser* lu = IS_LOCAL(dest);
+				if (lu)
+				{
+					SocketCertificateRequest req(&lu->eh, creator);
+					if (!req.cert)
+						return MODEACTION_DENY;
+				}
+				else
+				{
+					if(!IsSSLUser(creator, dest))
+						return MODEACTION_DENY;
+				}
 
 				dest->SetMode(this->GetModeChar(), true);
 				return MODEACTION_ALLOW;


### PR DESCRIPTION
The `UserCertificateRequest` method primarily used doesn't work when conn_umodes tries to set the mode as the underlying ExtItem does not yet exist. We can work around that when the user is local
(conn_umodes only acts on local users) by using the `SocketCertificateRequest` which will exist this early.  
While the majority of mode setting will be user on themselves which will call the Socket request each time, this keeps the messaging check and any possible remote user checking to the simpler ExtItem request.

Resolves #184.