### PR TITLE
Port all of my extras to 3.0.

### DIFF
--- a/3.0/m_blockinvite.cpp
+++ b/3.0/m_blockinvite.cpp
@@ -23,7 +23,7 @@
 /// $ModDesc: Provides usermode 'V' - block all INVITEs
 /* Set whether to reply with a blocked message to the source (inviter)
  * with the 'reply' config option. Defaults to no.
- * To allow oper overriding, add the privilege 'users/override-blockinvite'
+ * To allow oper overriding, add the privilege 'users/blockinvite-override'
  * to your preferred oper class.
  */
 
@@ -31,7 +31,7 @@
  * Find: '<helpop key="umodes" value="User Modes'
  * Place just before the 'W    Receives notif...' line
  V            Blocks all INVITEs from other users (requires
-              blockinvite extras-module).
+              the blockinvite extras-module).
  */
 
 
@@ -73,7 +73,7 @@ class ModuleBlockInvite : public Module
 		if (!IS_LOCAL(source) || !dest->IsModeSet(bi.GetModeChar()))
 			return MOD_RES_PASSTHRU;
 
-		if (source->HasPrivPermission("users/override-blockinvite"))
+		if (source->HasPrivPermission("users/blockinvite-override"))
 			return MOD_RES_PASSTHRU;
 
 		if (reply)

--- a/3.0/m_blockinvite.cpp
+++ b/3.0/m_blockinvite.cpp
@@ -1,0 +1,94 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <blockinvite reply="no">
+/// $ModDepends: core 3.0
+/// $ModDesc: Provides usermode 'V' - block all INVITEs
+/* Set whether to reply with a blocked message to the source (inviter)
+ * with the 'reply' config option. Defaults to no.
+ * To allow oper overriding, add the privilege 'users/override-blockinvite'
+ * to your preferred oper class.
+ */
+
+/* Helpop Lines for the UMODES section
+ * Find: '<helpop key="umodes" value="User Modes'
+ * Place just before the 'W    Receives notif...' line
+ V            Blocks all INVITEs from other users (requires
+              blockinvite extras-module).
+ */
+
+
+#include "inspircd.h"
+
+enum
+{
+	// From UnrealIRCd (channel mode, but same concept)
+	ERR_NOINVITE = 518
+};
+
+class ModuleBlockInvite : public Module
+{
+ private:
+	SimpleUserModeHandler bi;
+	bool reply;
+
+ public:
+	ModuleBlockInvite()
+		: bi(this, "blockinvite", 'V')
+		, reply(false)
+	{
+	}
+
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// Go before m_allowinvite as it returns ALLOW.
+		Module* allowinvite = ServerInstance->Modules->Find("m_allowinvite.so");
+		ServerInstance->Modules->SetPriority(this, I_OnUserPreInvite, PRIORITY_BEFORE, allowinvite);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		reply = ServerInstance->Config->ConfValue("blockinvite")->getBool("reply");
+	}
+
+	ModResult OnUserPreInvite(User* source, User* dest, Channel*, time_t) CXX11_OVERRIDE
+	{
+		if (!IS_LOCAL(source) || !dest->IsModeSet(bi.GetModeChar()))
+			return MOD_RES_PASSTHRU;
+
+		if (source->HasPrivPermission("users/override-blockinvite"))
+			return MOD_RES_PASSTHRU;
+
+		if (reply)
+		{
+			source->WriteNumeric(ERR_NOINVITE, InspIRCd::Format("Can't INVITE %s, they have +%c set",
+				dest->nick.c_str(), bi.GetModeChar()));
+		}
+
+		return MOD_RES_DENY;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Provides usermode +" + ConvToStr(bi.GetModeChar()) + " to block all INVITEs", VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleBlockInvite)

--- a/3.0/m_checkbans.cpp
+++ b/3.0/m_checkbans.cpp
@@ -1,0 +1,260 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2017-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModDepends: core 3.0
+/// $ModDesc: Adds commands /checkbans, /testban, and /whyban
+
+/* Helpop Lines for the CUSER section
+ * Find: '<helpop key="cuser" value="User Commands
+ * Place 'CHECKBANS', 'TESTBAN', and 'WHYBAN' in the
+ * command list accordingly. Re-space as needed.
+ * Find: '<helpop key="sslinfo" ...'
+ * Place just above that line:
+<helpop key="testban" value="/TESTBAN <channel> <mask>
+
+Test a channel ban mask against the users currently in the channel.">
+
+<helpop key="whyban" value="/WHYBAN <channel> [user]
+
+Get a list of bans and exceptions that match you (or the given user)
+on the specified channel.">
+
+<helpop key="checkbans" value="/CHECKBANS <channel>
+
+Get a list of bans and exceptions that match current users on the channel.">
+
+ */
+
+
+#include "inspircd.h"
+#include "listmode.h"
+
+enum
+{
+	RPL_BANMATCH = 540,
+	RPL_EXCEPTIONMATCH = 541,
+	RPL_ENDLIST = 542
+};
+
+namespace
+{
+bool CanCheck(Channel* chan, User* user)
+{
+	if (user->HasPrivPermission("channels/auspex"))
+		return true;
+
+	ModeHandler* ban = ServerInstance->Modes->FindMode("ban", MODETYPE_CHANNEL);
+	if (ban->GetLevelRequired(true) > chan->GetPrefixValue(user))
+	{
+		user->WriteNumeric(ERR_CHANOPRIVSNEEDED, chan->name, "You do not have access to modify the ban list.");
+		return false;
+	}
+
+	return true;
+}
+
+void CheckLists(User* source, Channel* chan, User* user)
+{
+	ListModeBase::ModeList* list;
+	ListModeBase::ModeList::const_iterator iter;
+	ModeHandler* ban = ServerInstance->Modes->FindMode("ban", MODETYPE_CHANNEL);
+	ModeHandler* exc = ServerInstance->Modes->FindMode("banexception", MODETYPE_CHANNEL);
+
+	ListModeBase* banlm = static_cast<ListModeBase*>(ban);
+	list = banlm->GetList(chan);
+	if (list)
+	{
+		for (iter = list->begin(); iter != list->end(); ++iter)
+		{
+			if (!chan->CheckBan(user, iter->mask))
+				continue;
+
+			source->WriteNumeric(RPL_BANMATCH, chan->name, InspIRCd::Format("Ban %s matches %s (set by %s on %s)",
+				iter->mask.c_str(), user->nick.c_str(), iter->setter.c_str(),
+				ServerInstance->TimeString(iter->time, "%Y-%m-%d %H:%M:%S UTC", true).c_str()));
+		}
+	}
+
+	if (!exc)
+		return;
+
+	ListModeBase* exclm = static_cast<ListModeBase*>(exc);
+	list = exclm->GetList(chan);
+	if (list)
+	{
+		for (iter = list->begin(); iter != list->end(); ++iter)
+		{
+			if (!chan->CheckBan(user, iter->mask))
+				continue;
+
+			source->WriteNumeric(RPL_EXCEPTIONMATCH, chan->name, InspIRCd::Format("Exception %s matches %s (set by %s on %s)",
+				iter->mask.c_str(), user->nick.c_str(), iter->setter.c_str(),
+				ServerInstance->TimeString(iter->time, "%Y-%m-%d %H:%M:%S UTC", true).c_str()));
+		}
+	}
+}
+} // namespace
+
+class CommandCheckBans : public Command
+{
+ public:
+	CommandCheckBans(Module* Creator) : Command(Creator, "CHECKBANS", 1, 1)
+	{
+		this->syntax = "<channel>";
+		this->Penalty = 6;
+	}
+
+	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		Channel* chan = ServerInstance->FindChan(parameters[0]);
+		if (!chan)
+		{
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
+			return CMD_FAILURE;
+		}
+
+		// Only allow checking for matching users if you have access to the ban list
+		if (!CanCheck(chan, user))
+			return CMD_FAILURE;
+
+		// Loop through all users of the channel, checking for matches to bans and exceptions (if available)
+		const Channel::MemberMap& users = chan->GetUsers();
+		for (Channel::MemberMap::const_iterator u = users.begin(); u != users.end(); ++u)
+			CheckLists(user, chan, u->first);
+
+		user->WriteNumeric(RPL_ENDLIST, chan->name, "End of check bans list");
+		return CMD_SUCCESS;
+	}
+};
+
+class CommandTestBan : public Command
+{
+ public:
+	CommandTestBan(Module* Creator) : Command(Creator, "TESTBAN", 2, 2)
+	{
+		this->syntax = "<channel> <mask>";
+		this->Penalty = 6;
+	}
+
+	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		Channel* chan = ServerInstance->FindChan(parameters[0]);
+		if (!chan)
+		{
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
+			return CMD_FAILURE;
+		}
+
+		// Only allow testing bans if the user has access to set a ban on the channel
+		if (!CanCheck(chan, user))
+			return CMD_FAILURE;
+
+		unsigned int matched = 0;
+		const Channel::MemberMap& users = chan->GetUsers();
+		for (Channel::MemberMap::const_iterator u = users.begin(); u != users.end(); ++u)
+		{
+			if (chan->CheckBan(u->first, parameters[1]))
+			{
+				user->WriteNumeric(RPL_BANMATCH, chan->name, InspIRCd::Format("Mask %s matches %s",
+					parameters[1].c_str(), u->first->nick.c_str()));
+				matched++;
+			}
+		}
+
+		if (matched > 0)
+		{
+			float percent = ((float)matched / (float)users.size()) * 100;
+			user->WriteNumeric(RPL_BANMATCH, chan->name, InspIRCd::Format("Mask %s matched %d of %lu users (%.2f%%).",
+						parameters[1].c_str(), matched, users.size(), percent));
+		}
+
+		user->WriteNumeric(RPL_ENDLIST, chan->name, parameters[1], "End of test ban list");
+		return CMD_SUCCESS;
+	}
+};
+
+class CommandWhyBan : public Command
+{
+ public:
+	CommandWhyBan(Module* Creator) : Command(Creator, "WHYBAN", 1, 2)
+	{
+		this->syntax = "<channel> [user]";
+	}
+
+	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		Channel* chan = ServerInstance->FindChan(parameters[0]);
+		if (!chan)
+		{
+			user->WriteNumeric(Numerics::NoSuchChannel(parameters[0]));
+			return CMD_FAILURE;
+		}
+
+		/* Allow checking yourself against channel bans with no access, but only
+		 * allow checking others if you have access to the channel ban list.
+		 */
+		User* u = parameters.size() == 1 ? user : NULL;
+		if (!u)
+		{
+			// Use a penalty of 10 when checking other users
+			LocalUser* lu = IS_LOCAL(user);
+			if (lu)
+				lu->CommandFloodPenalty += 10000;
+
+			if (!CanCheck(chan, user))
+				return CMD_FAILURE;
+
+			u = ServerInstance->FindNick(parameters[1]);
+			if (!u)
+			{
+				user->WriteNumeric(Numerics::NoSuchNick(parameters[1]));
+				return CMD_FAILURE;
+			}
+		}
+
+		// Check for matching bans and exceptions (if available)
+		CheckLists(user, chan, u);
+
+		user->WriteNumeric(RPL_ENDLIST, chan->name, u->nick, "End of why ban list");
+		return CMD_SUCCESS;
+	}
+};
+
+class ModuleCheckBans : public Module
+{
+	CommandCheckBans ccb;
+	CommandTestBan ctb;
+	CommandWhyBan cwb;
+
+ public:
+	ModuleCheckBans()
+		: ccb(this)
+		, ctb(this)
+		, cwb(this)
+	{
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Gives /checkbans, /testban, and /whyban - channel ban helper commands.");
+	}
+};
+
+MODULE_INIT(ModuleCheckBans)

--- a/3.0/m_conn_accounts.cpp
+++ b/3.0/m_conn_accounts.cpp
@@ -46,10 +46,7 @@ class ModuleConnAccounts : public Module
 			return MOD_RES_PASSTHRU;
 
 		const AccountExtItem* accountext = GetAccountExtItem();
-		if (!accountext)
-			return MOD_RES_DENY;
-
-		std::string* account = accountext->get(user);
+		const std::string* account = accountext ? accountext->get(user) : NULL;
 		if (!account)
 			return MOD_RES_DENY;
 

--- a/3.0/m_conn_accounts.cpp
+++ b/3.0/m_conn_accounts.cpp
@@ -1,0 +1,72 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <connect accounts="sally22 BillBob someoneElse">
+/// $ModDepends: core 3.0
+/// $ModDesc: Limit SASL connect classes by account(s).
+// "accounts" is a space separated list of EXACT matching account names.
+// This module requires that 'm_services_account' be loaded and will
+// respect the "requireaccount" setting.
+
+
+#include "inspircd.h"
+#include "modules/account.h"
+
+class ModuleConnAccounts : public Module
+{
+ public:
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// Go after services_account, it will deny non-authed clients
+		Module* servicesaccount = ServerInstance->Modules->Find("m_services_account.so");
+		ServerInstance->Modules->SetPriority(this, I_OnSetConnectClass, PRIORITY_AFTER, servicesaccount);
+	}
+
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* connclass) CXX11_OVERRIDE
+	{
+		const std::string accounts = connclass->config->getString("accounts");
+		if (accounts.empty() || !connclass->config->getBool("requireaccount"))
+			return MOD_RES_PASSTHRU;
+
+		const AccountExtItem* accountext = GetAccountExtItem();
+		if (!accountext)
+			return MOD_RES_DENY;
+
+		std::string* account = accountext->get(user);
+		if (!account)
+			return MOD_RES_DENY;
+
+		irc::spacesepstream ss(accounts);
+		for (std::string token; ss.GetToken(token); )
+		{
+			if (*account == token)
+				return MOD_RES_PASSTHRU;
+		}
+
+		return MOD_RES_DENY;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Limit SASL connect classes by account(s).");
+	}
+};
+
+MODULE_INIT(ModuleConnAccounts)

--- a/3.0/m_conn_matchident.cpp
+++ b/3.0/m_conn_matchident.cpp
@@ -1,0 +1,54 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2017-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <connect matchident="myIdent">
+/// $ModDepends: core 3.0
+/// $ModDesc: Allows a connect class to match by ident.
+
+
+#include "inspircd.h"
+
+class ModuleConnMatchIdent : public Module
+{
+ public:
+	void Prioritize() CXX11_OVERRIDE
+	{
+		/* Go after requireident, you better be using that with matching to ident */
+		Module* requireident = ServerInstance->Modules->Find("m_ident.so");
+		ServerInstance->Modules->SetPriority(this, I_OnSetConnectClass, PRIORITY_AFTER, requireident);
+	}
+
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* connclass) CXX11_OVERRIDE
+	{
+		const std::string matchident = connclass->config->getString("matchident");
+
+		if (!matchident.empty() && !InspIRCd::Match(user->ident, matchident))
+			return MOD_RES_DENY;
+
+		return MOD_RES_PASSTHRU;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Allows a connect class to match by ident.");
+	}
+};
+
+MODULE_INIT(ModuleConnMatchIdent)

--- a/3.0/m_conn_require.cpp
+++ b/3.0/m_conn_require.cpp
@@ -1,0 +1,537 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <connrequire timeout="5" ctcpstring="TIME" blockmessage="Your client isn't up to spec!">
+/// $ModDepends: core 3.0
+/// $ModDesc: Allow or block connections based on multiple criteria
+
+/* More available config tags:
+ * <dualversion active="yes" show="yes" ban="yes" duration="7d" reason="Fix your client!">
+ * <badversion mask="*terrible script*" reason="Your script is terrible, bye bye!">
+ * <badversion mask="xchat*" ban="yes" duration="7d" reason="Time to upgrade to Hexchat!">
+ * <banmissing cap="yes" version="yes" duration="14d" reason="Upgrade your client!">
+ * <banmissing ctcp="yes" duration="1d" reason="Don't ignore me!">
+ *
+ * Descriptions and defaults:
+ * <connrequire >
+ * timeout:        max number of seconds to hold a user while waiting for replies. Default: 5
+ * ctcpstring:     a secondary CTCP request, aside from "VERSION". Default: blank
+ * blockmessage:   a message sent to the user upon disconnect if we likely caused it. Default: blank
+ * disableversion: disable the CTCP "VERSION" request (leaves just CAP and ctcpstring useful). Default: no
+ * <dualversion >
+ * active:         controls the second "VERSION" request that blocks on mismatch. Default: no
+ * show:           send a SNOTICE of the two replies when they don't match. Default: no
+ * ban:            Z-Line the IP on a mismatch. Default: no
+ * duration:       time string for the Z-Line duration. Default: 7d
+ * reason:         used for both the block and Z-Line. Default: Fix your client!
+ * <badversion >
+ * mask:           wildcard mask to block/ban of an unwanted client version. Default: blank
+ * ban:            Z-Line the IP on a match. Default: no
+ * duration:       time string for the Z-Line duration. Default: 7d
+ * reason:         used for both the block and Z-Line. Default: Upgrade your client!
+ * <banmissing >
+ * cap:            whether a lack of CAP matches this tag. Default: no
+ * ctcp:           whether a lack of secondary CTCP (if enabled) reply matches this tag. Default: no
+ * version:        whether a lack of VERSION reply matches this tag. Default: no
+ * duration:       time string for the Z-Line duration. Default: 1d
+ * reason:         used for the Z-Line. Default: Fix your client!
+ *
+ * <badversion> and <banmissing> tags will be matched in the same order as they appear
+ * in the config.
+ *
+ * Connect class options:
+ * requirecap:		require the client to have requested CAP.
+ * requirectcp:		requre the client to have replied to the secondary CTCP request.
+ * requireversion:	require the client to have replied to the VERSION request.
+ * All three default to "no".
+ *
+ * The intent here is to harden your "open" connect classes with these options to
+ * deny them a connection. If you wish to Z-Line for certain reasons, use a
+ * <banmissing> tag. The dual version check acts on it's own.
+ * You can also use the <banversion> tags as freely as you wish.
+ *
+ * SNOTICES regarding blocked user connections are sent to SNOMASK 'u'
+ */
+
+/* NOTE: This module is not a direct replacement for m_requirectcp but is a
+ * complete rework of the original idea. They cannot be loaded at the same time.
+ */
+
+
+#include "inspircd.h"
+#include "xline.h"
+
+// ExtItem per User, tracking CAP request and CTCP replies
+struct UserData
+{
+	bool ccblocked;
+	bool ctcpreply;
+	bool expectctcp;
+	bool expectversion;
+	bool selfquit;
+	bool sentcap;
+	bool zapped;
+	std::string firstversionreply;
+	std::string secondversionreply;
+
+	UserData()
+		: ccblocked(false)
+		, ctcpreply(false)
+		, expectctcp(false)
+		, expectversion(false)
+		, selfquit(false)
+		, sentcap(false)
+		, zapped(false)
+	{
+	}
+};
+
+// Data from one <badversion> tag
+struct BadVersion
+{
+	bool ban;
+	time_t duration;
+	std::string mask;
+	std::string reason;
+};
+
+// Data from one <banmising> tag
+struct BanMissing
+{
+	bool cap;
+	bool ctcp;
+	bool version;
+	time_t duration;
+	std::string reason;
+};
+
+class ModuleConnRequire : public Module
+{
+	SimpleExtItem<UserData> userdata;
+
+	std::vector<BadVersion> badversions;
+	std::vector<BanMissing> banmissings;
+
+	bool dualversion;
+	bool dualshow;
+	bool dualban;
+	time_t dualduration;
+	std::string dualreason;
+
+	const char wrapper;
+	const std::string ctcpversion;
+	const std::string::size_type len_part;
+	const std::string::size_type len_all;
+	bool disableversion;
+	std::string ctcpstring;
+	std::string blockmessage;
+	time_t timeout;
+
+	void SetZLine(User* user, time_t duration, const std::string& reason, const std::string& from)
+	{
+		XLineFactory* xlf = ServerInstance->XLines->GetFactory("Z");
+		if (!xlf)
+			return;
+
+		const std::string& mask = user->GetIPString();
+		const std::string& source = ServerInstance->Config->ServerName;
+		const std::string timetype = (duration == 0 ? "permanent" : "timed");
+		const std::string expires = (duration == 0 ? "" : InspIRCd::Format(", expires in %s (on %s)",
+			InspIRCd::DurationString(duration).c_str(),
+			InspIRCd::TimeString(ServerInstance->Time() + duration).c_str()));
+
+		std::string dueto;
+		if (from == "dual")
+			dueto = "a version reply mismatch";
+		else if (from == "badversion")
+			dueto = "a match to a bad version";
+		else if (from == "banmissing")
+			dueto = "a match to a ban on missing data";
+
+		XLine* x = xlf->Generate(ServerInstance->Time(), duration, source, reason, mask);
+		if (ServerInstance->XLines->AddLine(x, NULL))
+		{
+			ServerInstance->SNO->WriteToSnoMask('x', "%s added %s Z-line for %s%s due to %s: %s", source.c_str(),
+				timetype.c_str(), mask.c_str(), expires.c_str(), dueto.c_str(), reason.c_str());
+		}
+		else
+			delete x;
+	}
+
+ public:
+	ModuleConnRequire ()
+		: userdata("userdata", ExtensionItem::EXT_USER, this)
+		, wrapper('\001')
+		, ctcpversion("VERSION")
+		, len_part(ctcpversion.length() + 2)
+		, len_all(len_part + 1)
+	{
+	}
+
+	void init() CXX11_OVERRIDE
+	{
+		if (ServerInstance->Modules->Find("m_requirectcp.so") != NULL)
+			throw ModuleException("You have m_requirectcp loaded! This module will not work correctly alongside that.");
+
+		ServerInstance->SNO->EnableSnomask('u', "CONN_REQUIRE");
+	}
+
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// Send the CTCP requests ASAP.
+		ServerInstance->Modules->SetPriority(this, I_OnSetUserIP, PRIORITY_FIRST);
+	}
+
+	void OnLoadModule(Module* mod) CXX11_OVERRIDE
+	{
+		// m_requirectcp will cause undesirable results
+		if (mod->ModuleSourceFile != "m_requirectcp.so")
+			return;
+
+		const std::string message = "Warning: m_conn_require will not work correctly alongside m_requirectcp.";
+		ServerInstance->SNO->WriteToSnoMask('a', message);
+		throw ModuleException(message);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("connrequire");
+		timeout = tag->getInt("timeout", 5, 1, 30);
+		disableversion = tag->getBool("disableversion");
+		ctcpstring = tag->getString("ctcpstring");
+		blockmessage = tag->getString("blockmessage");
+		std::transform(ctcpstring.begin(), ctcpstring.end(), ctcpstring.begin(), ::toupper);
+
+		tag = ServerInstance->Config->ConfValue("dualversion");
+		dualversion = tag->getBool("active");
+		dualshow = tag->getBool("showdual");
+		dualban = tag->getBool("ban");
+		dualduration = tag->getDuration("duration", 60*60*24*7);
+		dualreason = tag->getString("reason", "Fix your client!");
+
+		// No need to send VERSION here, it's already taken care of
+		if (ctcpstring == "VERSION")
+		{
+			throw ModuleException("Cannot use \"VERSION\" in secondary CTCP (\"ctcpstring\")");
+			ctcpstring.clear();
+		}
+
+		// Rebuild the badversions vector
+		badversions.clear();
+		ConfigTagList tags = ServerInstance->Config->ConfTags("badversion");
+		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		{
+			ConfigTag* itag = i->second;
+
+			const std::string mask = itag->getString("mask");
+
+			if (mask.empty())
+			{
+				throw ModuleException("Missing \"mask\" in <badversion> tag at " + itag->getTagLocation());
+				continue;
+			}
+
+			BadVersion bv;
+			bv.mask = mask;
+			bv.ban = itag->getBool("ban");
+			bv.duration = itag->getDuration("duration", 60*60*24*7);
+			bv.reason = itag->getString("reason", "Upgrade your client!");
+			badversions.push_back(bv);
+		}
+
+		// Rebuild the banmissings vector
+		banmissings.clear();
+		tags = ServerInstance->Config->ConfTags("banmissing");
+		for (ConfigIter i = tags.first; i != tags.second; ++i)
+		{
+			ConfigTag* itag = i->second;
+
+			BanMissing bm;
+			bm.cap = itag->getBool("cap");
+			bm.ctcp = itag->getBool("ctcp");
+			bm.version = itag->getBool("version");
+			bm.duration = itag->getDuration("duration", 60*60*24);
+			bm.reason = itag->getString("reason", "Fix your client!");
+			banmissings.push_back(bm);
+		}
+	}
+
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
+	{
+		// Allow user to be held here for up to 'timeout' seconds
+		if (user->signon + timeout <= ServerInstance->Time())
+			return MOD_RES_PASSTHRU;
+
+		UserData* ud = userdata.get(user);
+		if (!ud)
+			return MOD_RES_PASSTHRU;
+
+		// Hold while waiting for replies
+		if ((!disableversion && ud->firstversionreply.empty()) ||
+		   (dualversion && ud->secondversionreply.empty()) ||
+		   (!ctcpstring.empty() && !ud->ctcpreply))
+			return MOD_RES_DENY;
+
+		return MOD_RES_PASSTHRU;
+	}
+
+	ModResult OnPreCommand(std::string& command, CommandBase::Params& parameters, LocalUser* user, bool validated) CXX11_OVERRIDE
+	{
+		// Make sure we care about this user first
+		UserData* ud = userdata.get(user);
+		if (!ud)
+			return MOD_RES_PASSTHRU;
+
+		// Mark self quitters to avoid messaging or Z-Lining them
+		if (command == "QUIT")
+		{
+			ud->selfquit = true;
+			return MOD_RES_PASSTHRU;
+		}
+
+		// Now we check for three important things:
+		// 1) The command is a NOTICE (not yet validated)
+		// 2) The NOTICE is to us
+		// 3) The NOTICE contains at least one parameter after the target
+		if (command != "NOTICE" || validated || parameters.size() < 2 || parameters[0] != ServerInstance->Config->ServerName)
+			return MOD_RES_PASSTHRU;
+
+		const std::string& param = parameters[1];
+		// Check for length and the wrapper char
+		if (param.length() < 2 || param[0] != wrapper)
+			return MOD_RES_PASSTHRU;
+
+		// VERSION reply that we are expecting
+		if (!disableversion && ud->expectversion && !param.compare(1, ctcpversion.length(), ctcpversion))
+		{
+			const std::string& rplversion = (param.length() > len_part ? param.substr(len_part, param.length() - len_all) : "");
+			const std::string& firstversionreply = ud->firstversionreply;
+			const std::string& secondversionreply = ud->secondversionreply;
+
+			ud->expectversion = false;
+
+			// Ignore empty replies
+			if (rplversion.empty())
+				return MOD_RES_DENY;
+
+			// Check for a match to a configured <badversion>
+			for (std::vector<BadVersion>::const_iterator it = badversions.begin(); it != badversions.end(); ++it)
+			{
+				const BadVersion& bv = *it;
+				if (!InspIRCd::Match(rplversion, bv.mask))
+					continue;
+
+				if (bv.ban)
+					SetZLine(user, bv.duration, bv.reason, "badversion");
+
+				ServerInstance->SNO->WriteToSnoMask('u', "Blocked user %s (%s) [%s] on port %d, version reply \"%s\" matched badversion mask \"%s\"",
+					user->GetFullRealHost().c_str(), user->GetIPString().c_str(), user->GetRealName().c_str(), user->server_sa.port(), rplversion.c_str(), bv.mask.c_str());
+				ud->zapped = true;
+				ServerInstance->Users->QuitUser(user, bv.reason);
+
+				return MOD_RES_DENY;
+			}
+
+			// First reply
+			if (firstversionreply.empty())
+			{
+				ud->firstversionreply = rplversion;
+				if (dualversion)
+				{
+					ud->expectversion = true;
+					const std::string msg = wrapper + ctcpversion + wrapper;
+					ClientProtocol::Messages::Privmsg ctcp(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->Config->ServerName, user, msg);
+					user->Send(ServerInstance->GetRFCEvents().privmsg, ctcp);
+				}
+			}
+			// Second reply
+			else if (secondversionreply.empty())
+				ud->secondversionreply = rplversion;
+
+			if (dualversion && (!firstversionreply.empty() && !secondversionreply.empty() && firstversionreply != secondversionreply))
+			{
+				if (dualban)
+					SetZLine(user, dualduration, dualreason, "dual");
+
+				ServerInstance->SNO->WriteToSnoMask('u', "Blocked user %s (%s) [%s] from connecting on port %d for mismatched version replies",
+					user->GetFullRealHost().c_str(), user->GetIPString().c_str(), user->GetRealName().c_str(), user->server_sa.port());
+
+				if (dualshow)
+					ServerInstance->SNO->WriteToSnoMask('u', "Version replies \"%s\" and \"%s\"", firstversionreply.c_str(), secondversionreply.c_str());
+
+				ud->zapped = true;
+				ServerInstance->Users->QuitUser(user, dualreason);
+			}
+
+			return MOD_RES_DENY;
+		}
+		// Configurable CTCP string reply that we are expecting
+		else if (!ctcpstring.empty() && ud->expectctcp && !param.compare(1, ctcpstring.length(), ctcpstring))
+		{
+			ud->expectctcp = false;
+			ud->ctcpreply = true;
+
+			return MOD_RES_DENY;
+		}
+
+		return MOD_RES_PASSTHRU;
+	}
+
+	void OnPostCommand(Command* command, const CommandBase::Params& parameters, LocalUser* user, CmdResult result, bool loop) CXX11_OVERRIDE
+	{
+		if (command->name != "CAP")
+			return;
+
+		UserData* ud = userdata.get(user);
+
+		if (ud && !parameters.empty() && InspIRCd::Match(parameters[0], "LS"))
+			ud->sentcap = true;
+	}
+
+	ModResult OnSetConnectClass(LocalUser* user, ConnectClass* cc) CXX11_OVERRIDE
+	{
+		// Don't mess with the initial class setting
+		// This way we only act after the client has had time to send CAP or CTCP replies
+		if (user->registered != REG_NICKUSER)
+			return MOD_RES_PASSTHRU;
+
+		UserData* ud = userdata.get(user);
+		if (!ud)
+			return MOD_RES_PASSTHRU;
+
+		// Check class requirements against our UserData
+		if ((!cc->config->getBool("requirecap") || ud->sentcap) &&
+		   (disableversion || !cc->config->getBool("requireversion") || !ud->firstversionreply.empty()) &&
+		   (ctcpstring.empty() || !cc->config->getBool("requirectcp") || ud->ctcpreply))
+			return MOD_RES_PASSTHRU;
+
+		ud->ccblocked = true;
+		return MOD_RES_DENY;
+	}
+
+	// This matches with 2.0's placement of OnUserInit.
+	void OnSetUserIP(LocalUser* user) CXX11_OVERRIDE
+	{
+		// Initialize their UserData and send the CTCP request(s)
+		UserData* ud = new UserData;
+		userdata.set(user, ud);
+
+		if (!disableversion)
+		{
+			ud->expectversion = true;
+			const std::string msg = wrapper + ctcpversion + wrapper;
+			ClientProtocol::Messages::Privmsg ctcp(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->Config->ServerName, user, msg);
+			user->Send(ServerInstance->GetRFCEvents().privmsg, ctcp);
+		}
+		if (!ctcpstring.empty())
+		{
+			ud->expectctcp = true;
+			const std::string msg = wrapper + ctcpstring + wrapper;
+			ClientProtocol::Messages::Privmsg ctcp(ClientProtocol::Messages::Privmsg::nocopy, ServerInstance->Config->ServerName, user, msg);
+			user->Send(ServerInstance->GetRFCEvents().privmsg, ctcp);
+		}
+	}
+
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
+	{
+		// If they made it here, they passed; ditch their UserData
+		UserData* ud = userdata.get(user);
+		if (ud)
+			userdata.unset(user);
+	}
+
+	void OnUserDisconnect(LocalUser* user) CXX11_OVERRIDE
+	{
+		// Skip proper users
+		if (user->registered == REG_ALL)
+			return;
+
+		// Skip users with a socket level error
+		// This ignores things like port scans, ZNC cert errors, etc.
+		if (!user->eh.getError().empty())
+			return;
+
+		// Skip users we don't know about or that self quit
+		UserData* ud = userdata.get(user);
+		if (!ud || ud->selfquit)
+			return;
+
+		// We already disconnected (and possibly banned) these users
+		if (ud->zapped)
+			return;
+
+		// We didn't block any connect classes for this user.
+		if (!ud->ccblocked)
+		{
+			ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Unregistered user exiting for unknown reasons: %s (%s) [%s]",
+				user->GetFullRealHost().c_str(), user->GetIPString().c_str(), user->GetRealName().c_str());
+			return;
+		}
+
+		// Send them a message if configured
+		if (!blockmessage.empty())
+			user->WriteNotice(blockmessage);
+
+		bool noCap = !ud->sentcap;
+		bool noRpl = (!ctcpstring.empty() && !ud->ctcpreply);
+		bool noVer = (!disableversion && ud->firstversionreply.empty());
+
+		// Check for a match to our BanMissing and then Z-Line
+		for (std::vector<BanMissing>::const_iterator it = banmissings.begin(); it != banmissings.end(); ++it)
+		{
+			const BanMissing& bm = *it;
+
+			// We need to match a <banmissing> entirely. So if we want to match
+			// to missing version and ctcpstring but not cap, we need to skip
+			// any users that are missing cap; and so forth.
+			if (((!bm.cap && noCap) || (bm.cap && !noCap)) ||
+			   ((!bm.ctcp && noRpl) || (bm.ctcp && !noRpl)) ||
+			   ((!bm.version && noVer) || (bm.version && !noVer)))
+				continue;
+
+			SetZLine(user, bm.duration, bm.reason, "banmissing");
+		}
+
+		// Send out a SNOTICE that we likely caused this user to not get through
+		std::string buffer = "Unregistered user exiting: " + user->GetFullRealHost();
+		buffer.append(" (" + std::string(user->GetIPString()) + ") [" + user->GetRealName() + "]");
+		buffer.append(" on port " + ConvToStr(user->server_sa.port()));
+		buffer.append(". Possibly due to missing: ");
+		if (noCap)
+			buffer.append("CAP, ");
+		if (noRpl)
+			buffer.append(ctcpstring + " REPLY, ");
+		if (noVer)
+			buffer.append("VERSION REPLY");
+
+		// Remove trailing ", " if there
+		if (buffer[buffer.length() - 1] == ' ')
+			buffer.erase(buffer.length() - 2, 2);
+
+		ServerInstance->SNO->WriteToSnoMask('u', buffer);
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Allow or block connections based on multiple criteria");
+	}
+};
+
+MODULE_INIT(ModuleConnRequire)

--- a/3.0/m_conn_require.cpp
+++ b/3.0/m_conn_require.cpp
@@ -429,7 +429,7 @@ class ModuleConnRequire : public Module
 	// This matches with 2.0's placement of OnUserInit.
 	void OnSetUserIP(LocalUser* user) CXX11_OVERRIDE
 	{
-		if (user->registered != REG_NONE)
+		if (userdata.get(user))
 			return;
 
 		// Initialize their UserData and send the CTCP request(s)
@@ -455,8 +455,7 @@ class ModuleConnRequire : public Module
 	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
 	{
 		// If they made it here, they passed; ditch their UserData
-		UserData* ud = userdata.get(user);
-		if (ud)
+		if (userdata.get(user))
 			userdata.unset(user);
 	}
 

--- a/3.0/m_conn_require.cpp
+++ b/3.0/m_conn_require.cpp
@@ -429,6 +429,9 @@ class ModuleConnRequire : public Module
 	// This matches with 2.0's placement of OnUserInit.
 	void OnSetUserIP(LocalUser* user) CXX11_OVERRIDE
 	{
+		if (user->registered != REG_NONE)
+			return;
+
 		// Initialize their UserData and send the CTCP request(s)
 		UserData* ud = new UserData;
 		userdata.set(user, ud);

--- a/3.0/m_conn_require.cpp
+++ b/3.0/m_conn_require.cpp
@@ -426,12 +426,8 @@ class ModuleConnRequire : public Module
 		return MOD_RES_DENY;
 	}
 
-	// This matches with 2.0's placement of OnUserInit.
-	void OnSetUserIP(LocalUser* user) CXX11_OVERRIDE
+	void OnUserPostInit(LocalUser* user) CXX11_OVERRIDE
 	{
-		if (userdata.get(user))
-			return;
-
 		// Initialize their UserData and send the CTCP request(s)
 		UserData* ud = new UserData;
 		userdata.set(user, ud);

--- a/3.0/m_conn_strictsasl.cpp
+++ b/3.0/m_conn_strictsasl.cpp
@@ -61,13 +61,10 @@ class ModuleConnStrictSasl : public Module
 		if (!sentauth.get(user))
 			return MOD_RES_PASSTHRU;
 
-		const AccountExtItem* accountname = GetAccountExtItem();
-		if (!accountname)
-			return MOD_RES_PASSTHRU;
-
 		// Let them through if they have an account
-		std::string* account = accountname->get(user);
-		if (account && !account->empty())
+		const AccountExtItem* accountext = GetAccountExtItem();
+		const std::string* account = accountext ? accountext->get(user) : NULL;
+		if (account)
 			return MOD_RES_PASSTHRU;
 
 		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Failed SASL auth from: %s (%s) [%s]",

--- a/3.0/m_conn_strictsasl.cpp
+++ b/3.0/m_conn_strictsasl.cpp
@@ -1,0 +1,92 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <strictsasl reason="Fix your SASL authentication settings and try again.">
+/// $ModDepends: core 3.0
+/// $ModDesc: Disconnect users that fail a SASL auth.
+
+
+#include "inspircd.h"
+#include "modules/account.h"
+
+class ModuleConnStrictSasl : public Module
+{
+	LocalIntExt sentauth;
+	std::string reason;
+
+ public:
+	ModuleConnStrictSasl()
+		: sentauth("sentauth", ExtensionItem::EXT_USER, this)
+	{
+	}
+
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// m_cap will hold registration until 'CAP END', so SASL can try more than once
+		Module* cap = ServerInstance->Modules->Find("m_cap.so");
+		ServerInstance->Modules->SetPriority(this, I_OnCheckReady, PRIORITY_AFTER, cap);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		reason = ServerInstance->Config->ConfValue("strictsasl")->getString("reason", "Fix your SASL authentication settings and try again.");
+	}
+
+	void OnPostCommand(Command* command, const CommandBase::Params&, LocalUser* user, CmdResult, bool) CXX11_OVERRIDE
+	{
+		if (command->name == "AUTHENTICATE")
+			sentauth.set(user, 1);
+	}
+
+	ModResult OnCheckReady(LocalUser* user) CXX11_OVERRIDE
+	{
+		// Check that they have sent the AUTHENTICATE command
+		if (!sentauth.get(user))
+			return MOD_RES_PASSTHRU;
+
+		const AccountExtItem* accountname = GetAccountExtItem();
+		if (!accountname)
+			return MOD_RES_PASSTHRU;
+
+		// Let them through if they have an account
+		std::string* account = accountname->get(user);
+		if (account && !account->empty())
+			return MOD_RES_PASSTHRU;
+
+		ServerInstance->Logs->Log(MODNAME, LOG_DEBUG, "Failed SASL auth from: %s (%s) [%s]",
+			user->GetFullRealHost().c_str(), user->GetIPString().c_str(), user->GetRealName().c_str());
+		ServerInstance->Users->QuitUser(user, reason);
+		return MOD_RES_DENY;
+
+	}
+
+	void OnUserConnect(LocalUser* user) CXX11_OVERRIDE
+	{
+		if (sentauth.get(user))
+			sentauth.set(user, 0);
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Disconnect users that fail a SASL auth.");
+	}
+};
+
+MODULE_INIT(ModuleConnStrictSasl)

--- a/3.0/m_conn_vhost.cpp
+++ b/3.0/m_conn_vhost.cpp
@@ -37,10 +37,7 @@ class ModuleVhostOnConnect : public Module
 		std::string result;
 
 		const AccountExtItem* accountext = GetAccountExtItem();
-		if (!accountext)
-			return result;
-
-		std::string* account = accountext->get(user);
+		const std::string* account = accountext ? accountext->get(user) : NULL;
 		if (account)
 			result = *account;
 

--- a/3.0/m_extbanbanlist.cpp
+++ b/3.0/m_extbanbanlist.cpp
@@ -1,0 +1,131 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModDepends: core 3.0
+/// $ModDesc: Provides extban 'b' - Ban list from another channel
+
+/* Helpop Lines for the EXTBANS section
+ * Find: '<helpop key="extbans" value="Extended Bans'
+ * Place just before the 'j:<channel>' line:
+ b:<channel>   Matches users banned in the given channel (requires
+               the extbanbanlist extras-module).
+ */
+
+
+#include "inspircd.h"
+#include "listmode.h"
+
+class ExtbanBanlist : public ModeWatcher
+{
+	ChanModeReference& banmode;
+
+ public:
+	ExtbanBanlist(Module* parent, ChanModeReference& moderef)
+		: ModeWatcher(parent, "ban", MODETYPE_CHANNEL)
+		, banmode(moderef)
+	{
+	}
+
+	bool BeforeMode(User* source, User*, Channel* channel, std::string& param, bool adding) CXX11_OVERRIDE
+	{
+		if (!IS_LOCAL(source) || !channel || !adding || param.length() < 3)
+			return true;
+
+		// Check for a match to both a regular and nested extban
+		if ((param[0] != 'b' || param[1] != ':') && param.find(":b:") == std::string::npos)
+			return true;
+
+		std::string chan = param.substr(param.find("b:") + 2);
+
+		Channel* c = ServerInstance->FindChan(chan);
+		if (!c)
+		{
+			source->WriteNumeric(Numerics::NoSuchChannel(chan));
+			return false;
+		}
+
+		if (c == channel)
+		{
+			source->WriteNumeric(ERR_NOSUCHCHANNEL, chan, "Target channel must be a different channel");
+			return false;
+		}
+
+		if (banmode->GetLevelRequired(adding) > c->GetPrefixValue(source))
+		{
+			source->WriteNumeric(ERR_CHANOPRIVSNEEDED, chan, "You must have access to modify the banlist to use it");
+			return false;
+		}
+
+		return true;
+	}
+};
+
+class ModuleExtbanBanlist : public Module
+{
+	ChanModeReference banmode;
+	ExtbanBanlist eb;
+	bool checking;
+
+ public:
+	ModuleExtbanBanlist()
+		: banmode(this, "ban")
+		, eb(this, banmode)
+		, checking(false)
+	{
+	}
+
+	ModResult OnCheckBan(User* user, Channel* c, const std::string& mask) CXX11_OVERRIDE
+	{
+		if (!checking && (mask.length() > 2) && (mask[0] == 'b') && (mask[1] == ':'))
+		{
+			Channel* chan = ServerInstance->FindChan(mask.substr(2));
+			if (!chan)
+				return MOD_RES_PASSTHRU;
+
+			ListModeBase* banlm = static_cast<ListModeBase*>(*banmode);
+			const ListModeBase::ModeList* bans = banlm->GetList(chan);
+			if (!bans)
+				return MOD_RES_PASSTHRU;
+
+			for (ListModeBase::ModeList::const_iterator i = bans->begin(); i != bans->end(); ++i)
+			{
+				checking = true;
+				bool hit = chan->CheckBan(user, i->mask);
+				checking = false;
+
+				if (hit)
+					return MOD_RES_DENY;
+			}
+		}
+		return MOD_RES_PASSTHRU;
+	}
+
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
+	{
+		tokens["EXTBAN"].push_back('b');
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Extban 'b' - ban list from another channel", VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleExtbanBanlist)

--- a/3.0/m_extbanbanlist.cpp
+++ b/3.0/m_extbanbanlist.cpp
@@ -99,8 +99,8 @@ class ModuleExtbanBanlist : public Module
 			if (!chan)
 				return MOD_RES_PASSTHRU;
 
-			ListModeBase* banlm = static_cast<ListModeBase*>(*banmode);
-			const ListModeBase::ModeList* bans = banlm->GetList(chan);
+			ListModeBase* banlm = banmode->IsListModeBase();
+			const ListModeBase::ModeList* bans = banlm ? banlm->GetList(chan) : NULL;
 			if (!bans)
 				return MOD_RES_PASSTHRU;
 

--- a/3.0/m_extbanregex.cpp
+++ b/3.0/m_extbanregex.cpp
@@ -1,0 +1,262 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <extbanregex engine="pcre" opersonly="yes">
+/// $ModDepends: core 3.0
+/// $ModDesc: Provides extban 'x' - Regex matching to n!u@h\sr
+
+/* Since regex matching can be very CPU intensive, a config option is available
+ * to limit the use of this extban to opers only (defaults to true).
+ * A SNOTICE is sent to the 'a' SNOMASK if a match from this extban takes
+ * more than half a second.
+ */
+
+/* Helpop Lines for the EXTBANS section
+ * Find: '<helpop key="extbans" value="Extended Bans'
+ * Place after the 's:<server>' line:
+ x:<pattern>   Matches users to a regex pattern (requires a
+               regex module and extbanregex extras-module).
+ */
+
+
+#include "inspircd.h"
+#include "listmode.h"
+#include "modules/regex.h"
+
+namespace
+{
+enum
+{
+	ERR_NOENGINE = 543,
+	ERR_INVALIDMASK = 544
+};
+
+bool IsExtBanRegex(const std::string& mask)
+{
+	return ((mask.length() > 2) && (mask[0] == 'x') && (mask[1] == ':'));
+}
+
+bool IsNestedExtBanRegex(const std::string &mask)
+{
+	return ((mask.length() > 3) && (mask.find(":x:") != std::string::npos));
+}
+
+void RemoveAll(const std::string& engine, ChanModeReference& ban, ChanModeReference& exc, ChanModeReference& inv)
+{
+	std::vector<ListModeBase*> listmodes;
+	listmodes.push_back(static_cast<ListModeBase*>(*ban));
+	listmodes.push_back(static_cast<ListModeBase*>(*exc));
+	listmodes.push_back(static_cast<ListModeBase*>(*inv));
+
+	// Loop each channel checking for any regex extbans
+	// Batch removals with a Modes::ChangeList and Process()
+	// Send a notice to hop/op if anything was removed
+	const chan_hash& chans = ServerInstance->GetChans();
+	for (chan_hash::const_iterator c = chans.begin(); c != chans.end(); ++c)
+	{
+		Channel* chan = c->second;
+		Modes::ChangeList changelist;
+
+		for (std::vector<ListModeBase*>::const_iterator i = listmodes.begin(); i != listmodes.end(); ++i)
+		{
+			ListModeBase* lm = *i;
+			ListModeBase::ModeList* list = lm ? lm->GetList(chan) : NULL;
+			if (!list)
+				continue;
+
+			for (ListModeBase::ModeList::const_iterator iter = list->begin(); iter != list->end(); ++iter)
+			{
+				if (IsExtBanRegex(iter->mask) || IsNestedExtBanRegex(iter->mask))
+					changelist.push_remove(lm, iter->mask);
+			}
+		}
+
+		if (changelist.empty())
+			continue;
+
+		ServerInstance->Modes.Process(ServerInstance->FakeClient, chan, NULL, changelist);
+
+		const std::string msg = "Regex engine has changed to '" + engine + "'. All regex extbans have been removed";
+		PrefixMode* hop = ServerInstance->Modes->FindPrefixMode('h');
+		char pfxchar = (hop && hop->name == "halfop") ? hop->GetPrefix() : '@';
+
+		ClientProtocol::Messages::Privmsg notice(ServerInstance->FakeClient, chan, msg, MSG_NOTICE);
+		chan->Write(ServerInstance->GetRFCEvents().privmsg, notice, pfxchar);
+		ServerInstance->PI->SendChannelNotice(chan, pfxchar, msg);
+	}
+}
+} // namespace
+
+class WatchedMode : public ModeWatcher
+{
+	bool& opersonly;
+	dynamic_reference<RegexFactory>& rxfactory;
+
+ public:
+	WatchedMode(Module *mod, bool& oo, dynamic_reference<RegexFactory>& rf, const std::string modename)
+		: ModeWatcher(mod, modename, MODETYPE_CHANNEL)
+		, opersonly(oo)
+		, rxfactory(rf)
+	{
+	}
+
+	bool BeforeMode(User* user, User*, Channel* chan, std::string& param, bool adding) CXX11_OVERRIDE
+	{
+		if (!adding || !IS_LOCAL(user))
+			return true;
+
+		if (!IsExtBanRegex(param) && !IsNestedExtBanRegex(param))
+			return true;
+
+		if (opersonly && !user->IsOper())
+			return false;
+
+		if (!rxfactory)
+		{
+			user->WriteNumeric(ERR_NOENGINE, "Regex engine is missing, cannot set a regex extban.");
+			return false;
+		}
+
+		// Ensure mask is at least "!@", beyond that is up to the user
+		const std::string mask = param.substr(param.find("x:" + 2));
+		std::string::size_type plink = mask.find('!');
+		if (plink == std::string::npos || mask.find('@', plink) == std::string::npos)
+		{
+			user->WriteNumeric(ERR_INVALIDMASK, mask, "Regex extban mask must be n!u@h\\sr");
+			return false;
+		}
+
+		Regex* regex;
+		try
+		{
+			regex = rxfactory->Create(mask);
+			delete regex;
+		}
+		catch (ModuleException& e)
+		{
+			user->WriteNumeric(ERR_INVALIDMASK, mask, InspIRCd::Format("Regex extban mask is invalid (%s)",
+				e.GetReason().c_str()));
+			return false;
+		}
+
+		return true;
+	}
+};
+
+class ModuleExtBanRegex : public Module
+{
+	bool initing;
+	bool opersonly;
+	ChanModeReference banmode;
+	ChanModeReference banexceptionmode;
+	ChanModeReference inviteexceptionmode;
+	WatchedMode banwatcher;
+	WatchedMode exceptionwatcher;
+	WatchedMode inviteexceptionwatcher;
+
+	dynamic_reference<RegexFactory> rxfactory;
+	RegexFactory* factory;
+
+ public:
+	ModuleExtBanRegex()
+		: initing(true)
+		, opersonly(true)
+		, banmode(this, "ban")
+		, banexceptionmode(this, "banexception")
+		, inviteexceptionmode(this, "invex")
+		, banwatcher(this, opersonly, rxfactory, "ban")
+		, exceptionwatcher(this, opersonly, rxfactory, "banexception")
+		, inviteexceptionwatcher(this, opersonly, rxfactory, "invex")
+		, rxfactory(this, "regex")
+	{
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("extbanregex");
+		opersonly = tag->getBool("opersonly", true);
+		std::string newrxengine = tag->getString("engine");
+		factory = rxfactory ? rxfactory.operator->() : NULL;
+
+		if (newrxengine.empty())
+			rxfactory.SetProvider("regex");
+		else
+			rxfactory.SetProvider("regex/" + newrxengine);
+
+		if (!rxfactory)
+		{
+			if (newrxengine.empty())
+				ServerInstance->SNO->WriteToSnoMask('a', "WARNING: No regex engine loaded - regex extban functionality disabled until this is corrected.");
+			else
+				ServerInstance->SNO->WriteToSnoMask('a', "WARNING: Regex engine '%s' is not loaded - regex extban functionality disabled until this is corrected.", newrxengine.c_str());
+
+			RemoveAll("none", banmode, banexceptionmode, inviteexceptionmode);
+		}
+		else if (!initing && rxfactory.operator->() != factory)
+		{
+			ServerInstance->SNO->WriteToSnoMask('a', "Regex engine has changed to '%s', removing all regex extbans.", rxfactory->name.c_str());
+			RemoveAll(rxfactory->name, banmode, banexceptionmode, inviteexceptionmode);
+		}
+
+		initing = false;
+	}
+
+	ModResult OnCheckBan(User* user, Channel* chan, const std::string& mask) CXX11_OVERRIDE
+	{
+		if (!factory)
+			return MOD_RES_PASSTHRU;
+
+		if (!IsExtBanRegex(mask))
+			return MOD_RES_PASSTHRU;
+
+		std::string dhost = user->GetFullHost() + " " + user->GetRealName();
+		std::string host = user->GetFullRealHost() + " " + user->GetRealName();
+		std::string ip = user->nick + "!" + user->MakeHostIP() + " " + user->GetRealName();
+
+		struct timeval pretv, posttv;
+		gettimeofday(&pretv, NULL);
+
+		Regex* regex = factory->Create(mask.substr(2));
+		bool matched = (regex->Matches(dhost) || regex->Matches(host) || regex->Matches(ip));
+		delete regex;
+
+		gettimeofday(&posttv, NULL);
+		float timediff = ((double)(posttv.tv_usec - pretv.tv_usec) / 1000000) + (double)(posttv.tv_sec - pretv.tv_sec);
+		if (timediff > 0.5)
+		{
+			ServerInstance->SNO->WriteGlobalSno('a', "*** extbanregex match took %f seconds on %s %s",
+				timediff, chan->name.c_str(), mask.substr(2).c_str());
+		}
+
+		return (matched ? MOD_RES_DENY : MOD_RES_PASSTHRU);
+	}
+
+	void On005Numeric(std::map<std::string, std::string>& tokens) CXX11_OVERRIDE
+	{
+		tokens["EXTBAN"].push_back('x');
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Extban 'x' - regex matching to n!u@h\\sr", VF_OPTCOMMON, rxfactory ? rxfactory->name : "");
+	}
+};
+
+MODULE_INIT(ModuleExtBanRegex)

--- a/3.0/m_joinpartspam.cpp
+++ b/3.0/m_joinpartspam.cpp
@@ -1,0 +1,434 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2016-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <joinpartspam allowredirect="no" freeredirect="no">
+/// $ModDepends: core 3.0
+/// $ModDesc: Adds channel mode +x to block a user after x per y joins and parts/quits (join/part spam)
+
+/* Configuration and defaults:
+ * allowredirect: Whether channel redirection is allowed or not. Default: no
+ * freeredirect:  Skip the channel operator checks for redirection. Default: no
+ * TIP: You can remove a block on a user with a /INVITE
+ *
+ * Helpop Lines for the CHMODES section:
+ * Find: '<helpop key="chmodes" value="Channel Modes'
+ * Place just above the 'z     Blocks non-SSL...' line:
+ x <cycles>:<sec>:<block>[:#channel] Blocks a user after the set
+                    number of Join and Part/Quit cycles in the set
+                    seconds for the given block duration (seconds).
+                    An optional redirect channel can be set.
+ */
+
+
+#include "inspircd.h"
+
+enum
+{
+	RPL_CHANBLOCKED = 545
+};
+
+class joinpartspamsettings
+{
+	struct Tracking
+	{
+		time_t reset;
+		unsigned int counter;
+		Tracking() : reset(0), counter(0) { }
+	};
+
+	std::map<std::string, Tracking> cycler;
+	std::map<std::string, time_t> blocked;
+	time_t lastcleanup;
+
+ public:
+	unsigned int cycles;
+	unsigned int secs;
+	unsigned int block;
+	std::string redirect;
+
+	joinpartspamsettings(unsigned int c, unsigned int s, unsigned int b, std::string& r)
+		: lastcleanup(ServerInstance->Time())
+		, cycles(c)
+		, secs(s)
+		, block(b)
+		, redirect(r)
+	{
+	}
+
+	// Called by PostJoin to possibly reset a cycler's Tracking and increment the counter
+	void addcycle(const std::string& mask)
+	{
+		/* If mask isn't already tracked, set reset time
+		 * If tracked and reset time is up, reset counter and reset time
+		 * Also assume another server blocked, with the block timing out or a
+		 * user removed it if counter >= cycles, reset counter and reset time
+		 */
+		Tracking& tracking = cycler[mask];
+
+		if (tracking.reset == 0)
+			tracking.reset = ServerInstance->Time() + secs;
+		else if (ServerInstance->Time() > tracking.reset || tracking.counter >= cycles)
+		{
+			tracking.counter = 0;
+			tracking.reset = ServerInstance->Time() + secs;
+		}
+
+		++tracking.counter;
+
+		this->cleanup();
+	}
+
+	/* Called by PreJoin to check if a cycler's counter exceeds the set cycles,
+	 * adds them to the blocked list if so.
+	 * Will first clear a cycler if their reset time is up.
+	 */
+	bool zapme(const std::string& mask)
+	{
+		// Only check reset time and counter if they are already tracked as a cycler
+		std::map<std::string, Tracking>::iterator it = cycler.find(mask);
+		if (it == cycler.end())
+			return false;
+
+		const Tracking& tracking = it->second;
+
+		if (ServerInstance->Time() > tracking.reset)
+			cycler.erase(it);
+		else if (tracking.counter >= cycles)
+		{
+			blocked[mask] = ServerInstance->Time() + block;
+			cycler.erase(it);
+			return true;
+		}
+
+		return false;
+	}
+
+	// Check if a joining user is blocked, clear them if blocktime is up
+	bool isblocked(const std::string& mask)
+	{
+		std::map<std::string, time_t>::iterator it = blocked.find(mask);
+		if (it == blocked.end())
+			return false;
+
+		if (ServerInstance->Time() > it->second)
+			blocked.erase(it);
+		else
+			return true;
+
+		return false;
+	}
+
+	void removeblock(const std::string& mask)
+	{
+		std::map<std::string, time_t>::iterator it = blocked.find(mask);
+		if (it != blocked.end())
+			blocked.erase(it);
+	}
+
+	// Clear expired entries of non cyclers and blocked cyclers
+	void cleanup()
+	{
+		// 10 minutes should be a reasonable wait time
+		if (ServerInstance->Time() - lastcleanup < 600)
+			return;
+
+		lastcleanup = ServerInstance->Time();
+
+		for (std::map<std::string, Tracking>::iterator it = cycler.begin(); it != cycler.end(); )
+		{
+			const Tracking& tracking = it->second;
+
+			if (ServerInstance->Time() > tracking.reset)
+				cycler.erase(it++);
+			else
+				++it;
+		}
+
+		for (std::map<std::string, time_t>::iterator i = blocked.begin(); i != blocked.end(); )
+		{
+			if (ServerInstance->Time() > i->second)
+				blocked.erase(i++);
+			else
+				++i;
+		}
+	}
+};
+
+class JoinPartSpam : public ParamMode<JoinPartSpam, SimpleExtItem<joinpartspamsettings> >
+{
+	bool& allowredirect;
+	bool& freeredirect;
+
+	bool ParseCycles(irc::sepstream& stream, unsigned int& cycles)
+	{
+		std::string strcycles;
+		if (!stream.GetToken(strcycles))
+			return false;
+
+		unsigned int result = ConvToNum<unsigned int>(strcycles);
+		if (result < 2 || result > 20)
+			return false;
+
+		cycles = result;
+		return true;
+	}
+
+	bool ParseSeconds(irc::sepstream& stream, unsigned int& seconds)
+	{
+		std::string strseconds;
+		if (!stream.GetToken(strseconds))
+			return false;
+
+		unsigned int result = ConvToNum<unsigned int>(strseconds);
+		if (result < 1 || result > 43200)
+			return false;
+
+		seconds = result;
+		return true;
+	}
+
+	bool ParseRedirect(irc::sepstream& stream, std::string& redirect, User* source, Channel* chan)
+	{
+		std::string strredirect;
+		// This parameter is optional
+		if (!stream.GetToken(strredirect))
+			return true;
+
+		if (!allowredirect)
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, strredirect,
+				"Invalid join/part spam mode parameter, the server admin has disabled channel redirection."));
+			return false;
+		}
+
+		if (!ServerInstance->IsChannel(strredirect))
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, strredirect,
+				"Invalid join/part spam mode parameter, redirect channel needs to be a valid channel name."));
+			return false;
+		}
+
+		if (chan->name == strredirect)
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, strredirect,
+				"Invalid join/part spam mode parameter, cannot redirect to myself."));
+			return false;
+		}
+
+		Channel* c = ServerInstance->FindChan(strredirect);
+		if (!c)
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, strredirect,
+				"Invalid join/part spam mode parameter, redirect channel must exist."));
+			return false;
+		}
+
+		if (!freeredirect && c->GetPrefixValue(source) < HALFOP_VALUE)
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, strredirect,
+				"Invalid join/part spam mode parameter, you need at least halfop in the redirect channel."));
+			return false;
+		}
+
+		redirect = strredirect;
+		return true;
+	}
+
+ public:
+	JoinPartSpam(Module* Creator, bool& allow, bool& free)
+		: ParamMode<JoinPartSpam, SimpleExtItem<joinpartspamsettings> >(Creator, "joinpartspam", 'x')
+		, allowredirect(allow)
+		, freeredirect(free)
+	{
+	}
+
+	ModeAction OnSet(User* source, Channel* chan, std::string& parameter) CXX11_OVERRIDE
+	{
+		irc::sepstream stream(parameter, ':');
+		unsigned int cycles, secs, block;
+		cycles = secs = block = 0;
+		std::string redirect;
+
+		if (!ParseCycles(stream, cycles))
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, parameter,
+				"Invalid join/part spam mode parameter, 'cycles' needs to be between 2 and 20."));
+			return MODEACTION_DENY;
+		}
+		if (!ParseSeconds(stream, secs) || !ParseSeconds(stream, block))
+		{
+			source->WriteNumeric(Numerics::InvalidModeParameter(chan, this, parameter,
+				"Invalid join/part spam mode parameter, 'duration' and 'block time' need to be between 1 and 43200."));
+			return MODEACTION_DENY;
+		}
+		// Error message is sent from ParseRedirect()
+		if (!ParseRedirect(stream, redirect, source, chan))
+			return MODEACTION_DENY;
+
+		ext.set(chan, new joinpartspamsettings(cycles, secs, block, redirect));
+		return MODEACTION_ALLOW;
+	}
+
+	void SerializeParam(Channel* chan, joinpartspamsettings* jpss, std::string& out) CXX11_OVERRIDE
+	{
+		out.append(ConvToStr(jpss->cycles)).push_back(':');
+		out.append(ConvToStr(jpss->secs)).push_back(':');
+		out.append(ConvToStr(jpss->block));
+		if (!jpss->redirect.empty())
+		{
+			out.push_back(':');
+			out.append(jpss->redirect);
+		}
+	}
+};
+
+class ModuleJoinPartSpam : public Module
+{
+	bool allowredirect;
+	bool freeredirect;
+	JoinPartSpam jps;
+
+ public:
+	ModuleJoinPartSpam()
+		: allowredirect(false)
+		, freeredirect(false)
+		, jps(this, allowredirect, freeredirect)
+	{
+	}
+
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// Let bans, etc. stop the join first
+		ServerInstance->Modules->SetPriority(this, I_OnUserPreJoin, PRIORITY_LAST);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("joinpartspam");
+		allowredirect = tag->getBool("allowredirect");
+		freeredirect = tag->getBool("freeredirect");
+	}
+
+	// Check if the user is blocked or should now be blocked
+	bool BlockJoin(LocalUser* user, Channel* chan, bool quiet = false)
+	{
+		joinpartspamsettings* jpss = jps.ext.get(chan);
+		if (!jpss)
+			return false;
+
+		const std::string& mask(user->MakeHost());
+
+		if (jpss->isblocked(mask))
+		{
+			if (quiet)
+				return true;
+
+			user->WriteNumeric(RPL_CHANBLOCKED, chan->name, InspIRCd::Format("Channel join/part spam triggered (limit is %u cycles in %u secs). Please try again later.",
+				jpss->cycles, jpss->secs));
+
+			return true;
+		}
+		else if (jpss->zapme(mask))
+		{
+			if (quiet)
+				return true;
+
+			// The user is now in the blocked list, deny the join, and if
+			// redirect is wanted and allowed, we join the user to that channel.
+			user->WriteNumeric(RPL_CHANBLOCKED, chan->name, InspIRCd::Format("Channel join/part spam triggered (limit is %u cycles in %u secs). Please try again in %u seconds.",
+				jpss->cycles, jpss->secs, jpss->block));
+
+			if (allowredirect && !jpss->redirect.empty())
+				Channel::JoinUser(user, jpss->redirect);
+			return true;
+		}
+
+		return false;
+	}
+
+	// Catch /CYCLE, deny if the user is going to be blocked
+	ModResult OnPreCommand(std::string& command, CommandBase::Params& parameters, LocalUser* user, bool validated) CXX11_OVERRIDE
+	{
+		if (!validated || command != "CYCLE" || user->IsOper())
+			return MOD_RES_PASSTHRU;
+
+		Channel* chan = ServerInstance->FindChan(parameters[0]);
+		if (!chan || !chan->IsModeSet(&jps))
+			return MOD_RES_PASSTHRU;
+
+		bool deny = BlockJoin(user, chan, true);
+		if (!deny)
+			return MOD_RES_PASSTHRU;
+
+		user->WriteNotice(InspIRCd::Format("*** You may not cycle, as you would then trigger the join/part spam protection on channel %s",
+			chan->name.c_str()));
+		return MOD_RES_DENY;
+	}
+
+	// Block the join if the user is blocked (already or as of now)
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
+	{
+		if (!chan || !chan->IsModeSet(&jps))
+			return MOD_RES_PASSTHRU;
+		if (user->IsOper())
+			return MOD_RES_PASSTHRU;
+
+		return BlockJoin(user, chan) ? MOD_RES_DENY : MOD_RES_PASSTHRU;
+	}
+
+	// Only count successful joins
+	void OnUserJoin(Membership* memb, bool sync, bool created, CUList& excepts) CXX11_OVERRIDE
+	{
+		if (sync)
+			return;
+		if (created || !memb->chan->IsModeSet(&jps))
+			return;
+		if (memb->user->IsOper())
+			return;
+
+		joinpartspamsettings* jpss = jps.ext.get(memb->chan);
+		if (jpss)
+		{
+			const std::string& mask(memb->user->MakeHost());
+			jpss->addcycle(mask);
+		}
+	}
+
+	// Remove a block on a user on a successful invite
+	void OnUserInvite(User*, User* user, Channel* chan, time_t, unsigned int, CUList&) CXX11_OVERRIDE
+	{
+		if (!chan->IsModeSet(&jps))
+			return;
+
+		joinpartspamsettings* jpss = jps.ext.get(chan);
+		if (!jpss)
+			return;
+
+		const std::string& mask(user->MakeHost());
+		jpss->removeblock(mask);
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Provides channel mode +" + ConvToStr(jps.GetModeChar()) + " for blocking Join/Part spammers.", VF_OPTCOMMON);
+	}
+};
+
+MODULE_INIT(ModuleJoinPartSpam)

--- a/3.0/m_nocreate.cpp
+++ b/3.0/m_nocreate.cpp
@@ -1,0 +1,325 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2016-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <nocreate telluser="no" noisy="yes">
+/// $ModDepends: core 3.0
+/// $ModDesc: Adds oper command '/nocreate' to block a user from creating new channels
+
+/* Credit due to the authors and maintainers of 'm_cban', as most of this code is directly borrowed to work in the same manner
+ * See <https://github.com/inspircd/inspircd/blob/insp3/src/modules/m_cban.cpp>
+ * As well as the base XLine and G/Z-Line commands code.
+ *
+ * Configuration and defaults:
+ * telluser: tell the user they are blocked from creating a channel instead of a generic error. Default: no
+ * noisy:    sends an SNOTICE when a blocked user tries to create a channel. Default: yes
+ *
+ * Helpop Lines for the COPER section:
+ * Find: '<helpop key="coper" value="Oper Commands
+ * Place 'NOCREATE' in the appropriate ordered spot.
+ * Find: '<helpop key="wallops" ...'
+ * Place just above that line:
+<helpop key="nocreate" value="/NOCREATE <nick!user@hostmask> [<duration> :<reason>]
+
+Sets or removes a no channel creation ban on a user. You must
+specify all three parameters to add a ban, and just the mask to
+remove a ban. Mask can be a valid, online nickname and will use
+'*!*@<IP>' as a mask.">
+
+ */
+
+
+#include "inspircd.h"
+#include "xline.h"
+#include "modules/stats.h"
+
+// Store the NoCreate mask as an XLine
+class NoCreate : public XLine
+{
+	std::string mask;
+
+ public:
+
+	NoCreate(time_t s_time, unsigned long d, const std::string& src, const std::string& re, const std::string& ma)
+		: XLine(s_time, d, src, re, "NOCREATE")
+		, mask(ma)
+	{
+	}
+
+	bool Matches(User* u) CXX11_OVERRIDE
+	{
+		return (InspIRCd::Match(u->GetFullHost(), this->mask) ||
+			InspIRCd::Match(u->GetFullRealHost(), this->mask) ||
+			InspIRCd::MatchCIDR(u->nick+"!"+u->ident+"@"+u->GetIPString(), this->mask));
+	}
+
+	bool Matches(const std::string& s) CXX11_OVERRIDE
+	{
+		return (InspIRCd::MatchCIDR(s, this->mask));
+	}
+
+	void DisplayExpiry() CXX11_OVERRIDE
+	{
+		ServerInstance->SNO->WriteToSnoMask('x', "Removing expired NoCreate %s (set by %s %s ago): %s",
+			this->mask.c_str(), this->source.c_str(),
+			InspIRCd::DurationString(ServerInstance->Time() - this->set_time).c_str(), this->reason.c_str());
+	}
+
+	std::string& Displayable() CXX11_OVERRIDE
+	{
+		return this->mask;
+	}
+};
+
+// A specialized XLineFactory for NOCREATE pointers
+class NoCreateFactory : public XLineFactory
+{
+ public:
+	NoCreateFactory() : XLineFactory("NOCREATE") { }
+
+	XLine* Generate(time_t set_time, unsigned long duration, const std::string& source, const std::string& reason, const std::string& xline_specific_mask) CXX11_OVERRIDE
+	{
+		return new NoCreate(set_time, duration, source, reason, xline_specific_mask);
+	}
+
+	bool AutoApplyToUserList(XLine* x) CXX11_OVERRIDE
+	{
+		return false;
+	}
+};
+
+// Handle /NOCREATE
+class CommandNoCreate : public Command
+{
+ private:
+	// Specialized Insane ban check, checks that both nick and userhost match.
+	// To use the existing InspIRCd functions would mean running through the
+	// user list twice, as nick and host insane checks are separate functions.
+	bool MaskIsInsane(const std::string& mask, User* user)
+	{
+		unsigned int matches = 0;
+
+		float itrigger = ServerInstance->Config->ConfValue("insane")->getFloat("trigger", 95.5);
+
+		std::string nick;
+		std::string userhost;
+
+		std::string::size_type n = mask.find('!');
+		// This should never happen; but just incase it does, return false
+		if (n == std::string::npos)
+			return false;
+
+		nick = mask.substr(0, n);
+		userhost = mask.substr(n+1);
+
+		const user_hash& users = ServerInstance->Users->GetUsers();
+		for (user_hash::const_iterator u = users.begin(); u != users.end(); ++u)
+		{
+			if (InspIRCd::Match(u->second->nick, nick) &&
+				(InspIRCd::Match(u->second->MakeHost(), userhost, ascii_case_insensitive_map) ||
+				InspIRCd::MatchCIDR(u->second->MakeHostIP(), userhost, ascii_case_insensitive_map)))
+			{
+				matches++;
+			}
+		}
+
+		if (!matches)
+			return false;
+
+		float percent = ((float)matches / (float)users.size()) * 100;
+		if (percent > itrigger)
+		{
+			ServerInstance->SNO->WriteToSnoMask('a', "\2WARNING\2: %s tried to set a NoCreate mask of %s, which covers %.2f%% of the network!",
+				user->nick.c_str(), mask.c_str(), percent);
+			return true;
+		}
+
+		return false;
+	}
+
+ public:
+	CommandNoCreate(Module* Creator) : Command(Creator, "NOCREATE", 1, 3)
+	{
+		flags_needed = 'o';
+		this->syntax = "<nick!user@hostmask> [<duration> :<reason>]";
+	}
+
+	CmdResult Handle(User* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		std::string target = parameters[0];
+		User* u = ServerInstance->FindNick(target);
+
+		// Allow just 'nick' if valid, otherwise force use of 'nick!user@host'
+		if (target.find('!') == std::string::npos || target.find('@') == std::string::npos)
+		{
+			if (u && u->registered == REG_ALL)
+			{
+				// Use *!*@IP if valid nick is given
+				target = std::string("*!*@") + u->GetIPString();
+			}
+			else
+			{
+				user->WriteNotice(InspIRCd::Format("*** NoCreate: No user '%s' found", target.c_str()));
+				return CMD_FAILURE;
+			}
+		}
+
+		// Adding
+		if (parameters.size() >= 3)
+		{
+			if (this->MaskIsInsane(target, user))
+			{
+				user->WriteNotice(InspIRCd::Format("*** NoCreate mask %s flagged as insane", target.c_str()));
+				return CMD_FAILURE;
+			}
+
+			unsigned long duration;
+			if (!InspIRCd::Duration(parameters[1], duration))
+			{
+				user->WriteNotice("*** Invalid duration for NoCreate.");
+				return CMD_FAILURE;
+			}
+
+			NoCreate* nc = new NoCreate(ServerInstance->Time(), duration, user->nick, parameters[2], target);
+			if (ServerInstance->XLines->AddLine(nc, user))
+			{
+				if (!duration)
+				{
+					ServerInstance->SNO->WriteToSnoMask('x', "%s added permanent NoCreate for %s: %s",
+						user->nick.c_str(), target.c_str(), parameters[2].c_str());
+				}
+				else
+				{
+					ServerInstance->SNO->WriteToSnoMask('x', "%s added timed NoCreate for %s, expires in %s (on %s): %s",
+						user->nick.c_str(), target.c_str(), InspIRCd::DurationString(duration).c_str(),
+						ServerInstance->TimeString(ServerInstance->Time() + duration).c_str(), parameters[2].c_str());
+				}
+			}
+			else
+			{
+				delete nc;
+				user->WriteNotice(InspIRCd::Format("*** NoCreate for %s already exists", target.c_str()));
+				return CMD_FAILURE;
+			}
+		}
+		// Removing
+		else
+		{
+			std::string reason;
+			if (ServerInstance->XLines->DelLine(target.c_str(), "NOCREATE", reason, user))
+			{
+				ServerInstance->SNO->WriteToSnoMask('x', "%s removed NoCreate on %s: %s",
+					user->nick.c_str(), target.c_str(), reason.c_str());
+			}
+			else
+			{
+				user->WriteNotice(InspIRCd::Format("*** NoCreate %s not found in list, try /stats N", target.c_str()));
+				return CMD_FAILURE;
+			}
+		}
+
+		return CMD_SUCCESS;
+	}
+
+	RouteDescriptor GetRouting(User* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		if (IS_LOCAL(user))
+			return ROUTE_LOCALONLY; // spanningtree will send ADDLINE
+
+		return ROUTE_BROADCAST;
+	}
+};
+
+// Main module class for NOCREATE
+class ModuleNoCreate : public Module, public Stats::EventListener
+{
+	CommandNoCreate cmd;
+	NoCreateFactory f;
+	bool telluser;
+	bool noisy;
+
+ public:
+	ModuleNoCreate()
+		: Stats::EventListener(this)
+		, cmd(this)
+	{
+	}
+
+	void init() CXX11_OVERRIDE
+	{
+		ServerInstance->XLines->RegisterFactory(&f);
+	}
+
+	~ModuleNoCreate()
+	{
+		ServerInstance->XLines->DelAll("NOCREATE");
+		ServerInstance->XLines->UnregisterFactory(&f);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("nocreate");
+		telluser = tag->getBool("telluser");
+		noisy = tag->getBool("noisy", true);
+	}
+
+	ModResult OnStats(Stats::Context& stats) CXX11_OVERRIDE
+	{
+		if (stats.GetSymbol() != 'N')
+			return MOD_RES_PASSTHRU;
+
+		ServerInstance->XLines->InvokeStats("NOCREATE", 210, stats);
+		return MOD_RES_DENY;
+	}
+
+	ModResult OnUserPreJoin(LocalUser* user, Channel* chan, const std::string& cname, std::string& privs, const std::string& keygiven) CXX11_OVERRIDE
+	{
+		// Do nothing if the channel already exists or if the user is either an oper or exempt
+		if (chan)
+			return MOD_RES_PASSTHRU;
+		if (user->IsOper() || user->exempt)
+			return MOD_RES_PASSTHRU;
+
+		XLine* nc = ServerInstance->XLines->MatchesLine("NOCREATE", user);
+
+		if (nc)
+		{
+			// User is blocked from creating channels
+			if (telluser)
+				user->WriteNumeric(ERR_BANNEDFROMCHAN, cname, "You are not allowed to create channels");
+			else
+				user->WriteNumeric(Numerics::NoSuchChannel(cname));
+
+			if (noisy)
+				ServerInstance->SNO->WriteGlobalSno('a', "%s tried to create channel %s but is blocked from doing so (%s)",
+					user->nick.c_str(), cname.c_str(), nc->reason.c_str());
+
+			return MOD_RES_DENY;
+		}
+
+		return MOD_RES_PASSTHRU;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Gives /nocreate, an XLine to block a user from creating new channels");
+	}
+};
+
+MODULE_INIT(ModuleNoCreate)

--- a/3.0/m_randomnotice.cpp
+++ b/3.0/m_randomnotice.cpp
@@ -1,0 +1,105 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *   Copyright (C) 2010 Daniel De Graaf <danieldg@inspircd.org>
+ *   Copyright (C) 2007-2008 Robin Burchell <robin+git@viroteck.net>
+ *   Copyright (C) 2007 Dennis Friis <peavey@inspircd.org>
+ *   Copyright (C) 2003, 2006 Craig Edwards <craigedwards@brainbox.cc>
+ *   Copyright (C) 2005 Craig McLure <craig@chatspike.net>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <randomnotice file="randomnotices.txt" interval="30m" prefix="" suffix="">
+/// $ModDepends: core 3.0
+/// $ModDesc: Send a random notice (quote) from a file to all users at a set interval.
+// "file" needs to be a text file with each 'notice' on a new line
+// "interval" is a time-string (1y7d8h6m3s format)
+
+
+#include "inspircd.h"
+
+class RandomNoticeTimer : public Timer
+{
+ public:
+	std::vector<std::string> notices;
+	std::string prefix;
+	std::string suffix;
+
+	RandomNoticeTimer() : Timer(1800, true) { }
+
+	bool Tick(time_t) CXX11_OVERRIDE
+	{
+		if (notices.empty())
+			return false;
+
+		unsigned long random = ServerInstance->GenRandomInt(notices.size());
+		const std::string& notice = notices[random];
+
+		for (UserManager::LocalList::const_iterator i = ServerInstance->Users.GetLocalUsers().begin(); i != ServerInstance->Users.GetLocalUsers().end(); ++i)
+		{
+			LocalUser* user = *i;
+
+			if (user->registered == REG_ALL)
+				user->WriteNotice(prefix + notice + suffix);
+		}
+
+		return true;
+	}
+};
+
+class ModuleRandomNotice : public Module
+{
+	RandomNoticeTimer* timer;
+
+ public:
+	ModuleRandomNotice()
+	{
+		timer = new RandomNoticeTimer();
+	}
+
+	~ModuleRandomNotice()
+	{
+		ServerInstance->Timers.DelTimer(timer);
+	}
+
+	void init() CXX11_OVERRIDE
+	{
+		ServerInstance->Timers.AddTimer(timer);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("randomnotice");
+		FileReader reader(tag->getString("file", "randomnotices.txt"));
+		timer->notices = reader.GetVector();
+		timer->prefix = tag->getString("prefix");
+		timer->suffix = tag->getString("suffix");
+		unsigned long interval = tag->getDuration("interval", 1800, 60, 31536000);
+		if (timer->GetInterval() != interval)
+			timer->SetInterval(interval);
+
+		if (timer->notices.empty())
+			throw ModuleException("Random Notices file is empty!! Please add quotes to the file.");
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Send a random notice (quote) to all users at a set interval.");
+	}
+};
+
+MODULE_INIT(ModuleRandomNotice)

--- a/3.0/m_restrictmsg_duration.cpp
+++ b/3.0/m_restrictmsg_duration.cpp
@@ -108,13 +108,10 @@ class ModuleRestrictMsgDuration : public Module
 		// Source is registered (and identified) exemption
 		if (exemptregistered)
 		{
-			const AccountExtItem* accountname = GetAccountExtItem();
-			if (accountname)
-			{
-				const std::string* account = accountname->get(src);
-				if (account && !account->empty())
-					return MOD_RES_PASSTHRU;
-			}
+			const AccountExtItem* accountext = GetAccountExtItem();
+			const std::string* account = accountext ? accountext->get(src) : NULL;
+			if (account)
+				return MOD_RES_PASSTHRU;
 		}
 
 		if (notify)

--- a/3.0/m_restrictmsg_duration.cpp
+++ b/3.0/m_restrictmsg_duration.cpp
@@ -1,0 +1,146 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is part of InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModConfig: <restrictmsg_duration duration="1m" target="both" notify="no" exemptoper="yes" exemptuline="yes" exemptregistered="yes">
+/// $ModDepends: core 3.0
+/// $ModDesc: Restrict messages until a user has been connected for a specified duration.
+
+/* Config descriptions:
+ * duration:         time string for how long after sign on to restrict messages. Default: 1m
+ * target:           which targets to block: user, chan, or both. Default: both
+ * notify:           whether to let the user know their message was blocked. Default: no
+ * exemptoper:       whether to exempt messages to opers. Default: yes
+ * exemptuline:      whether to exempt messages to U-Lined clients (services). Default: yes
+ * exemptregistered: whether to exempt messages from registered (and identified) users. Default: yes
+ * Connect Class exemption (add to any connect class block you wish to exempt from this):
+ * exemptrestrictmsg="yes"
+ */
+
+
+#include "inspircd.h"
+#include "modules/account.h"
+
+class ModuleRestrictMsgDuration : public Module
+{
+	bool blockuser;
+	bool blockchan;
+	bool exemptoper;
+	bool exemptuline;
+	bool exemptregistered;
+	bool notify;
+	time_t duration;
+
+ public:
+	void Prioritize() CXX11_OVERRIDE
+	{
+		// Go last to let filter, +R, bans, etc. act first
+		ServerInstance->Modules->SetPriority(this, PRIORITY_LAST);
+	}
+
+	void ReadConfig(ConfigStatus&) CXX11_OVERRIDE
+	{
+		ConfigTag* tag = ServerInstance->Config->ConfValue("restrictmsg_duration");
+
+		const std::string target = tag->getString("target", "both");
+		if (target != "user" && target != "chan" && target != "both")
+		{
+			throw ModuleException("Invalid \"target\" of '" + target + "' in <restrictmsg_duration>. Default of both will be used.");
+		}
+
+		blockuser = (target != "chan");
+		blockchan = (target != "user");
+		exemptoper = tag->getBool("exemptoper", true);
+		exemptuline = tag->getBool("exemptuline", true);
+		exemptregistered = tag->getBool("exemptregistered", true);
+		notify = tag->getBool("notify");
+		duration = tag->getDuration("duration", 60);
+	}
+
+	ModResult OnUserPreMessage(User* user, const MessageTarget& target, MessageDetails& details) CXX11_OVERRIDE
+	{
+		LocalUser* src = IS_LOCAL(user);
+		// Only check against non-oper local users
+		if (!src || src->IsOper())
+			return MOD_RES_PASSTHRU;
+
+		// Check their connected duration
+		if (src->signon + duration <= ServerInstance->Time())
+			return MOD_RES_PASSTHRU;
+
+		// Check for connect class exemption
+		if (src->MyClass->config->getBool("exemptrestrictmsg"))
+			return MOD_RES_PASSTHRU;
+
+		if (target.type == MessageTarget::TYPE_USER)
+		{
+			if (!blockuser)
+				return MOD_RES_PASSTHRU;
+
+			User* const dst = target.Get<User>();
+
+			// Target is Oper exemption
+			if (exemptoper && dst->IsOper())
+				return MOD_RES_PASSTHRU;
+			// Target is on a U-Lined server exemption
+			if (exemptuline && dst->server->IsULine())
+				return MOD_RES_PASSTHRU;
+		}
+		else if (target.type == MessageTarget::TYPE_CHANNEL && !blockchan)
+			return MOD_RES_PASSTHRU;
+
+		// Source is registered (and identified) exemption
+		if (exemptregistered)
+		{
+			const AccountExtItem* accountname = GetAccountExtItem();
+			if (accountname)
+			{
+				const std::string* account = accountname->get(src);
+				if (account && !account->empty())
+					return MOD_RES_PASSTHRU;
+			}
+		}
+
+		if (notify)
+		{
+			if (target.type == MessageTarget::TYPE_USER)
+			{
+				src->WriteNumeric(ERR_CANTSENDTOUSER, target.Get<User>()->nick,
+					InspIRCd::Format("You cannot send messages within the first %lu seconds of connecting.",
+					duration));
+			}
+			else
+			{
+				src->WriteNumeric(ERR_CANNOTSENDTOCHAN, target.Get<Channel>()->name,
+					InspIRCd::Format("You cannot send messages within the first %lu seconds of connecting.",
+					duration));
+			}
+		}
+
+		// Finally, deny them the message sending ability :D
+		return MOD_RES_DENY;
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("Restrict messages until a user has been connected for a specified duration.");
+	}
+};
+
+MODULE_INIT(ModuleRestrictMsgDuration)

--- a/3.0/m_xlinetools.cpp
+++ b/3.0/m_xlinetools.cpp
@@ -1,0 +1,606 @@
+/*
+ * InspIRCd -- Internet Relay Chat Daemon
+ *
+ *   Copyright (C) 2018-2019 Matt Schatz <genius3000@g3k.solutions>
+ *
+ * This file is a module for InspIRCd.  InspIRCd is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// $ModAuthor: genius3000
+/// $ModAuthorMail: genius3000@g3k.solutions
+/// $ModDepends: core 3.0
+/// $ModDesc: X-line management with XCOPY, XCOUNT, XREMOVE, and XSEARCH
+
+/* XCOUNT, XREMOVE, and XSEARCH are the same except for the end action:
+ * XCOUNT will just return a count of matching X-lines.
+ * XREMOVE will remove the matching X-lines and return that count.
+ * XSEARCH will list the matching X-lines and that count.
+ * Syntax is argument and value style "-arg=val" and is the same for each.
+ * All arguments are optional:
+ * -type=<xline type or *>
+ * -mask=<mask> CIDR supported>
+ * -reason=<reason> Spaces allowed
+ * -source=<source> Nick, server, or "<Config>" ("setby" can be used instead of "source")
+ * -set=<time string> (time ago) Prefix with '-' for less than
+ * -duration=<time string> (actual set duration) Exact match, prefix '+' for longer than, or '-' for shorter than
+ * -expires=<time string> (time ahead) Prefix with '+' for more than
+ *
+ * XCOPY copies a specified X-line (by type and mask) to a
+ * new X-line of same type with a new mask.
+ * Original reason and expiry time are copied but can be
+ * overridden with the 'duration' or 'reason' arguments.
+ *
+ * Note: Both XCOPY and XREMOVE will check for the appropriate
+ * command permissions before acting.
+ */
+
+/* Helpop Lines for the COPER section
+ * Find: '<helpop key="coper" value="Oper Commands
+ * Add 'XCOPY XCOUNT XREMOVE XSEARCH' before 'ZLINE'
+ * and space accordingly to match.
+ * Find: '<helpop key="kline" ...'
+ * Place just above that line:
+<helpop key="xcopy" value="/XCOPY <X-line type> <old mask> <new mask> [-duration=<> -reason=<>]
+
+Copies the specified X-line (if found) to a new X-line. The original reason and expiry time
+are copied unless overridden with '-duration=' or '-reason='">
+
+<helpop key="xcount" value="/XCOUNT -type=<X-line type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
+
+Returns a count of matching X-lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
+is a nick, server, or <Config>. 'Prefix your value for these 3 arguments with a '!' to negate the match. 't' is a
+time-string (seconds or 1y2w3d4h5m6s) and can be prefixed with '+' or '-' to adjust matching. All arguments are optional.">
+
+<helpop key="xremove" value="/XREMOVE -type=<X-line type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
+
+Removes matching X-lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
+is a nick, server, or <Config>. 'Prefix your value for these 3 arguments with a '!' to negate the match. 't' is a
+time-string (seconds or 1y2w3d4h5m6s) and can be prefixed with '+' or '-' to adjust matching. All arguments are optional.
+Use /XSEARCH to test before removing.">
+
+<helpop key="xsearch" value="/XSEARCH -type=<X-line type|*> -mask=[!]<m> -reason=[!]<r> -source=[!]<s> -set=[-]<t> -duration=[-+]<t> -expires=[+]<t>
+
+Lists matching X-lines of the specified type (or all types). Mask(m) supports CIDR, reason(r) can include spaces, source(s)
+is a nick, server, or <Config>. Prefix your value for these 3 arguments with a '!' to negate the match. 't' is a
+time-string (seconds or 1y2w3d4h5m6s) and can be prefixed with '+' or '-' to adjust matching. All arguments are optional.">
+
+ */
+
+
+#include "inspircd.h"
+#include "xline.h"
+
+struct Criteria
+{
+	std::string type;
+	std::string mask;
+	std::string reason;
+	std::string source;
+	std::string set;
+	std::string duration;
+	std::string expires;
+
+	Criteria() { }
+	Criteria(const std::string& t, const std::string& m, const std::string& r, const std::string& s)
+		: type(t)
+		, mask(m)
+		, reason(r)
+		, source(s)
+	{
+	}
+};
+
+namespace
+{
+	bool HasPermission(LocalUser* user, std::string type)
+	{
+		if (type.length() <= 2)
+			type.append("LINE");
+
+		return user->HasPermission(type);
+	}
+
+	bool ProcessArgs(const CommandBase::Params& params, Criteria& args)
+	{
+		if (!params.size())
+			return false;
+
+		// Track arg reason to include space separated params
+		bool argreason = false;
+
+		const std::string mtype("-type=");
+		const std::string mmask("-mask=");
+		const std::string mreason("-reason=");
+		const std::string msource("-source=");
+		const std::string msetby("-setby=");
+		const std::string mset("-set=");
+		const std::string mduration("-duration=");
+		const std::string mexpires("-expires=");
+
+		for (std::vector<std::string>::const_iterator p = params.begin(); p != params.end(); ++p)
+		{
+			const std::string param = *p;
+
+			if (param.find(mtype) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val(param.substr(mtype.length()));
+				args.type = (!val.empty() ? val : "*");
+			}
+			else if (param.find(mmask) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val(param.substr(mmask.length()));
+				args.mask = (!val.empty() ? val : "*");
+			}
+			else if (param.find(mreason) != std::string::npos)
+			{
+				argreason = true;
+				const std::string val(param.substr(mreason.length()));
+				args.reason = (!val.empty() ? val : "*");
+			}
+			else if (param.find(msource) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val(param.substr(msource.length()));
+				args.source = (!val.empty() ? val : "*");
+			}
+			else if (param.find(msetby) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val(param.substr(msetby.length()));
+				args.source = (!val.empty() ? val : "*");
+			}
+			else if (param.find(mset) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val = param.substr(mset.length());
+				args.set = (ServerInstance->Duration(val) ? val : "");
+			}
+			else if (param.find(mduration) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val = param.substr(mduration.length());
+				// 0 is a special case here, to match no expires
+				if (val == "0")
+					args.duration = val;
+				else
+					args.duration = (ServerInstance->Duration(val) ? val : "");
+			}
+			else if (param.find(mexpires) != std::string::npos)
+			{
+				argreason = false;
+				const std::string val = param.substr(mexpires.length());
+				args.expires = (ServerInstance->Duration(val) ? val : "");
+			}
+			else
+			{
+				if (argreason)
+					args.reason.append(" " + param);
+				else
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	const std::string BuildCriteriaStr(const Criteria& args)
+	{
+		std::string criteria;
+		const std::string sep(", ");
+
+		if (args.mask != "*")
+			criteria.append("Mask: " + args.mask + sep);
+		if (args.reason != "*")
+			criteria.append("Reason: " + args.reason + sep);
+		if (args.source != "*")
+			criteria.append("Source: " + args.source + sep);
+		if (!args.set.empty())
+			criteria.append("Set: " + args.set + sep);
+		if (!args.duration.empty())
+			criteria.append("Duration: " + args.duration + sep);
+		if (!args.expires.empty())
+			criteria.append("Expires: " + args.expires + sep);
+
+		if (criteria.empty())
+			criteria.append("No specific criteria");
+		// Remove trailing separator
+		else if (criteria[criteria.length() - 1] == ' ')
+			criteria.erase(criteria.length() - 2, 2);
+
+		return criteria;
+	}
+
+	const std::string BuildTypeStr(const std::string& type)
+	{
+		std::string typestr;
+
+		// Core/Vendor *-lines are single character, some -extras are two
+		// Other X-lines look better without -lines
+		if (type.length() <= 2)
+			typestr = type + "-line";
+		else
+			typestr = type;
+
+		return typestr;
+	}
+}
+
+class CommandXBase : public SplitCommand
+{
+	void ProcessLines(LocalUser* user, const Criteria& args, const std::string& linetype, XLineLookup* xlines, unsigned int& matched, unsigned int& total, const bool count, const bool remove)
+	{
+		total += xlines->size();
+		LookupIter safei;
+		bool negate;
+		bool match;
+
+		for (LookupIter i = xlines->begin(); i != xlines->end(); )
+		{
+			safei = i;
+			safei++;
+
+			XLine* xline = i->second;
+
+			// CIDR and glob mask matching, with negation
+			negate = args.mask[0] == '!';
+			match = InspIRCd::MatchCIDR(xline->Displayable(), (negate ? args.mask.substr(1) : args.mask));
+			if ((negate && match) || (!negate && !match))
+			{
+				i = safei;
+				continue;
+			}
+
+			// Glob reason matching, with negation
+			negate = args.reason[0] == '!';
+			match = InspIRCd::Match(xline->reason, (negate ? args.reason.substr(1) : args.reason));
+			if ((negate && match) || (!negate && !match))
+			{
+				i = safei;
+				continue;
+			}
+
+			// Glob source matching, with negation
+			negate = args.source[0] == '!';
+			match = InspIRCd::Match(xline->source, (negate ? args.source.substr(1) : args.source));
+			if ((negate && match) || (!negate && !match))
+			{
+				i = safei;
+				continue;
+			}
+
+			// Set (time ago): Prefix '-' means less than; no prefix means more than; both match exact (to the second)
+			if (!args.set.empty())
+			{
+				long set = ServerInstance->Time() - ServerInstance->Duration(args.set);
+
+				if ((args.set[0] == '-' && xline->set_time < set) ||
+				    (args.set[0] != '-' && xline->set_time > set))
+				{
+					i = safei;
+					continue;
+				}
+			}
+
+			// Duration: Prefix '+' means longer than; '-' means shorter than; no prefix means exact; '0' matches no expiry
+			if (!args.duration.empty())
+			{
+				unsigned long duration = ServerInstance->Duration(args.duration);
+
+				if ((xline->duration == 0 && args.duration != "0") ||
+				    (args.duration[0] == '+' && xline->duration <= duration) ||
+				    (args.duration[0] == '-' && xline->duration >= duration) ||
+				    (args.duration.find_first_not_of("+-") == 0 && xline->duration != duration))
+				{
+					i = safei;
+					continue;
+				}
+			}
+
+			// Expires (time ahead): Prefix '+' means more than; no prefix means less than; both match exact (to the second)
+			if (!args.expires.empty())
+			{
+				unsigned long expires = ServerInstance->Time() + ServerInstance->Duration(args.expires);
+
+				if ((xline->duration == 0) ||
+				    (args.expires[0] == '+' && xline->set_time + xline->duration < expires) ||
+				    (args.expires[0] != '+' && xline->set_time + xline->duration > expires))
+				{
+					i = safei;
+					continue;
+				}
+			}
+
+			matched++;
+
+			// Skip the rest when just counting matches
+			if (count)
+			{
+				i = safei;
+				continue;
+			}
+
+			std::string expires;
+			const std::string display = xline->Displayable();
+			const std::string duration = (xline->duration == 0 ? "permanent" : InspIRCd::DurationString(xline->duration));
+			const std::string reason = xline->reason;
+			const std::string settime = ServerInstance->TimeString(xline->set_time);
+			if (xline->duration == 0)
+				expires = "doesn't expire";
+			else
+				expires = InspIRCd::Format("expires in %s (on %s)",
+					InspIRCd::DurationString(xline->expiry - ServerInstance->Time()).c_str(),
+					ServerInstance->TimeString(xline->expiry).c_str());
+
+			std::string ret;
+			if (remove && ServerInstance->XLines->DelLine(display.c_str(), linetype, ret, user))
+			{
+				ServerInstance->SNO->WriteToSnoMask('x', "%s removed %s on %s: %s", user->nick.c_str(),
+					BuildTypeStr(linetype).c_str(), display.c_str(), reason.c_str());
+			}
+			else if (!remove)
+			{
+				user->WriteNotice(InspIRCd::Format("%s on %s set by %s on %s, duration '%s', %s: %s",
+					BuildTypeStr(linetype).c_str(), display.c_str(), xline->source.c_str(),
+					settime.c_str(), duration.c_str(), expires.c_str(), reason.c_str()));
+			}
+
+			i = safei;
+		}
+	}
+
+	bool HandleCmd(LocalUser* user, const Criteria& args, Command* cmd)
+	{
+		bool count = (cmd->name == "XCOUNT");
+		bool remove = (cmd->name == "XREMOVE");
+		const std::string action = (remove ? "Removing" : "Listing");
+		const std::string criteria = BuildCriteriaStr(args);
+		unsigned int matched = 0;
+		unsigned int total = 0;
+
+		if (args.type == "*")
+		{
+			if (!count)
+				user->WriteNotice(InspIRCd::Format("%s matches from all X-line types (%s)",
+					action.c_str(), criteria.c_str()));
+
+			std::vector<std::string> xlinetypes = ServerInstance->XLines->GetAllTypes();
+			for (std::vector<std::string>::const_iterator x = xlinetypes.begin(); x != xlinetypes.end(); ++x)
+			{
+				// If removing, check for the command permission for this type
+				if (remove && !HasPermission(user, *x))
+				{
+					user->WriteNotice(InspIRCd::Format("Skipping type '%s' as oper type '%s' does not have access to remove these.",
+						(*x).c_str(), user->oper->name.c_str()));
+					continue;
+				}
+
+				XLineLookup* xlines = ServerInstance->XLines->GetAll(*x);
+				if (xlines)
+					ProcessLines(user, args, *x, xlines, matched, total, count, remove);
+			}
+
+			if (count)
+				user->WriteNotice(InspIRCd::Format("%u of %u X-lines matched (%s)",
+					matched, total, criteria.c_str()));
+			else
+				user->WriteNotice(InspIRCd::Format("End of list, %u/%u X-lines %s",
+					matched, total, (remove ? "removed" : "matched")));
+		}
+		else
+		{
+			std::string linetype = args.type;
+			std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
+
+			// Check for the command permission to remove X-lines of this type
+			if (remove && !HasPermission(user, linetype))
+			{
+				user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to remove X-lines of type '%s'",
+					user->nick.c_str(), user->oper->name.c_str(), linetype.c_str());
+				return false;
+			}
+
+			XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
+			if (!xlines)
+			{
+				user->WriteNotice(InspIRCd::Format("Invalid X-line type '%s' (or not yet used X-line)",
+					linetype.c_str()));
+				return false;
+			}
+			if (xlines->empty())
+			{
+				user->WriteNotice(InspIRCd::Format("No X-lines of type '%s' exist", linetype.c_str()));
+				return false;
+			}
+
+			if (!count)
+				user->WriteNotice(InspIRCd::Format("%s matches of X-line type '%s' (%s)",
+					action.c_str(), linetype.c_str(), criteria.c_str()));
+
+			ProcessLines(user, args, linetype, xlines, matched, total, count, remove);
+
+			if (count)
+				user->WriteNotice(InspIRCd::Format("%u of %u X-lines of type '%s' matched (%s)",
+					matched, total, linetype.c_str(), criteria.c_str()));
+			else
+				user->WriteNotice(InspIRCd::Format("End of list, %u/%u X-lines of type '%s' %s",
+					matched, total, linetype.c_str(), (remove ? "removed" : "matched")));
+		}
+
+		return true;
+	}
+
+ public:
+	CommandXBase(Module* Creator, const std::string& cmdname) : SplitCommand(Creator, cmdname, 1)
+	{
+		syntax = "-type=<type|*> -mask=[!]<> -reason=[!]<> -source=[!]<> -set=[-]<time> -duration=[-+]<time> -expires=[+]<time>";
+		flags_needed = 'o';
+	}
+
+	CmdResult HandleLocal(LocalUser* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		if (parameters[0][0] != '-' || parameters[0].find('=') == std::string::npos)
+		{
+			user->WriteNotice(InspIRCd::Format("Incorrect argument syntax \"%s\"", parameters[0].c_str()));
+			return CMD_FAILURE;
+		}
+
+		// Initialize type, mask, reason, and source with match-all
+		Criteria args("*", "*", "*", "*");
+		if (!ProcessArgs(parameters, args))
+		{
+			user->WriteNotice("There was a problem processing the given arguments");
+			return CMD_FAILURE;
+		}
+
+		// Failure message is sent from HandleCmd()
+		if (!HandleCmd(user, args, this))
+			return CMD_FAILURE;
+
+		return CMD_SUCCESS;
+	}
+};
+
+class CommandXCopy : public SplitCommand
+{
+ public:
+	CommandXCopy(Module* Creator) : SplitCommand(Creator, "XCOPY", 3)
+	{
+		syntax = "<X-line type> <old mask> <new mask> [-duration=<> -reason=<>]";
+		flags_needed = 'o';
+	}
+
+	CmdResult HandleLocal(LocalUser* user, const Params& parameters) CXX11_OVERRIDE
+	{
+		const std::string& xtype = parameters[0];
+		const std::string& oldmask = parameters[1];
+		const std::string& newmask = parameters[2];
+		Criteria args;
+
+		if (parameters.size() > 3)
+		{
+			CommandBase::Params optional(parameters.begin() + 3, parameters.end());
+			if (!ProcessArgs(optional, args))
+			{
+				user->WriteNotice("There was a problem processing the given arguments");
+				return CMD_FAILURE;
+			}
+		}
+
+		// Lookup the X-line matching what we were given
+		std::string linetype = xtype;
+		std::transform(linetype.begin(), linetype.end(), linetype.begin(), ::toupper);
+
+		// Check for the command permission to copy this type of X-line
+		if (!HasPermission(user, linetype))
+		{
+			user->WriteNumeric(ERR_NOPRIVILEGES, "%s :Permission Denied - Oper type '%s' does not have access to copy an X-line of type '%s'",
+				user->nick.c_str(), user->oper->name.c_str(), linetype.c_str());
+			return CMD_FAILURE;
+		}
+
+		XLineLookup* xlines = ServerInstance->XLines->GetAll(linetype);
+		if (!xlines)
+		{
+			user->WriteNotice(InspIRCd::Format("Invalid X-line type '%s' (or not yet used X-line)", linetype.c_str()));
+			return CMD_FAILURE;
+		}
+
+		XLine* oldxline = NULL;
+		for (LookupIter i = xlines->begin(); i != xlines->end(); ++i)
+		{
+			if (i->second->Displayable() == oldmask)
+			{
+				oldxline = i->second;
+				break;
+			}
+		}
+
+		if (!oldxline)
+		{
+			user->WriteNotice(InspIRCd::Format("Could not find \"%s\" in %ss",
+				oldmask.c_str(), BuildTypeStr(linetype).c_str()));
+			return CMD_FAILURE;
+		}
+
+		// We don't know the proper mask format for this, so we compare it with the old one
+		if ((oldmask.find('!') != std::string::npos && newmask.find('!') == std::string::npos) ||
+		    (oldmask.find('!') == std::string::npos && newmask.find('!') != std::string::npos) ||
+		    (oldmask.find('@') != std::string::npos && newmask.find('@') == std::string::npos) ||
+		    (oldmask.find('@') == std::string::npos && newmask.find('@') != std::string::npos))
+		{
+			user->WriteNotice("Old and new mask must follow the same format (n!u@h or u@h or h)");
+			return CMD_FAILURE;
+		}
+
+		// Get the needed X-line Factory and create the new X-line
+		// Snagged this method from m_xline_db
+		XLineFactory* xlf = ServerInstance->XLines->GetFactory(linetype);
+		if (!xlf)
+		{
+			user->WriteNotice("Great! You just broke the matrix!");
+			return CMD_FAILURE;
+		}
+
+		unsigned long duration;
+		if (!args.duration.empty())
+			duration = ServerInstance->Duration(args.duration);
+		else
+			duration = (oldxline->duration == 0 ? 0 : (oldxline->set_time + oldxline->duration - ServerInstance->Time()));
+
+		const std::string& reason = (!args.reason.empty() ? args.reason : oldxline->reason);
+		const std::string expires = (duration == 0 ? "" : InspIRCd::Format(", expires in %s (on %s)",
+			InspIRCd::DurationString(duration).c_str(),
+			InspIRCd::TimeString(ServerInstance->Time() + duration).c_str()));
+
+		XLine* newxline = xlf->Generate(ServerInstance->Time(), duration, user->nick, reason, newmask);
+		if (ServerInstance->XLines->AddLine(newxline, user))
+			ServerInstance->SNO->WriteToSnoMask('x', "%s added %s %s for %s%s: %s", user->nick.c_str(),
+				(duration == 0 ? "permanent" : "timed"), BuildTypeStr(linetype).c_str(),
+				newmask.c_str(), expires.c_str(), reason.c_str());
+		else
+		{
+			user->WriteNotice(InspIRCd::Format("Failed to add %s on \"%s\"",
+				BuildTypeStr(linetype).c_str(), newmask.c_str()));
+			delete newxline;
+			return CMD_FAILURE;
+		}
+
+		return CMD_SUCCESS;
+	}
+};
+
+class ModuleXLineTools : public Module
+{
+	CommandXBase xcount;
+	CommandXBase xremove;
+	CommandXBase xsearch;
+	CommandXCopy xcopy;
+
+ public:
+	ModuleXLineTools()
+		: xcount(this, "XCOUNT")
+		, xremove(this, "XREMOVE")
+		, xsearch(this, "XSEARCH")
+		, xcopy(this)
+	{
+	}
+
+	Version GetVersion() CXX11_OVERRIDE
+	{
+		return Version("X-line management tools");
+	}
+};
+
+MODULE_INIT(ModuleXLineTools)


### PR DESCRIPTION
Port all of my extras to 3.0.
Reviews and testing appreciated.

### Modules List
- [x] m_blockinvite
- [x] m_checkbans
- [x] m_conn_accounts
- [x] m_conn_matchident
- [x] m_conn_require
- [x] m_conn_strictsasl
- [x] m_conn_vhost (minor code improvement)
- [x] m_extbanbanlist
- [x] m_extbanregex
- [x] m_joinpartspam
- [x] m_nocreate
- [x] m_randomnotice
- [x] m_restrictmsg_duration
- [x] m_xlinetools

#### List of my remaining extras not needing a port:
- m_classban: Exists in 3.0.
- m_sasl_servercheck: Handled properly in 3.0.
- m_showfile: Exists in 3.0.
- m_sslmodeuser: Exists in 3.0.