### PR TITLE
m_shed_users: reset SIGUSR2 to SIG_IGN on unload

### DIFF
--- a/3.0/m_shed_users.cpp
+++ b/3.0/m_shed_users.cpp
@@ -285,7 +285,7 @@ class ModuleShedUsers
 
 	~ModuleShedUsers() CXX11_OVERRIDE
 	{
-		signal(SIGUSR2, SIG_DFL);
+		signal(SIGUSR2, SIG_IGN);
 		me = NULL;
 	}
 


### PR DESCRIPTION
This keeps it in line with the default value set in the inspircd core